### PR TITLE
:rock: [Boundary_Condition] out-of-line definitions

### DIFF
--- a/cxx/CMakeLists.txt
+++ b/cxx/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(lbmbench::header ALIAS lbmbench_header)
 
 add_library(lbmbench_library
   lbm/core/Bounding_Box.cpp
+  lbm/core/Boundary_Condition.cpp
   lbm/core/Lattice.cpp
   lbm/core/Expression.cpp
   lbm/core/Euclidean.cpp

--- a/cxx/lbm/core/Boundary_Condition.cpp
+++ b/cxx/lbm/core/Boundary_Condition.cpp
@@ -1,0 +1,251 @@
+#include <lbm/core/Boundary_Condition.hpp>
+
+namespace lbm::core {
+
+  //
+  // ... Boundary_Conditions
+  //
+  json
+  Boundary_Conditions::get_json() const {
+    json j = static_cast<const Base &>(*this);
+    return j;
+  }
+
+  void
+  Boundary_Conditions::set_json(const json &j) {
+    Base::clear();
+    transform(std::begin(j),
+              std::end(j),
+              back_inserter(*this),
+              [](const json &bc) -> Boundary_Condition { return bc; });
+  }
+
+  //
+  // ... Boundary_Condition
+  Boundary_ID
+  Boundary_Condition::boundary() const {
+    return std::visit([](const auto &bc) -> Boundary_ID { return bc.boundary(); },
+                      static_cast<const Base &>(*this));
+  }
+
+  void
+  to_json(json &j, const Boundary_Condition &boundary_condition) {
+    visit([&](const auto &boundary_condition) { j = boundary_condition; }, boundary_condition);
+  }
+
+  void
+  from_json(const json &j, Boundary_Condition &boundary_condition) {
+    if (j.contains("wall")) {
+      boundary_condition = Wall(j);
+    } else if (j.contains("symmetry")) {
+      boundary_condition = Symmetry(j);
+    } else if (j.contains("inlet")) {
+      boundary_condition = Inlet(j);
+    } else if (j.contains("outlet")) {
+      boundary_condition = Outlet(j);
+    } else if (j.contains("pressureDrop")) {
+      boundary_condition = Pressure_Drop(j);
+    }
+  }
+
+  ostream &
+  operator<<(ostream &os, const Boundary_Condition &boundary_condition) {
+    return os << json(boundary_condition);
+  }
+
+  istream &
+  operator>>(istream &is, Boundary_Condition &boundary_condition) {
+    boundary_condition = json::parse(is);
+    return is;
+  }
+
+  bool
+  operator==(const Boundary_Condition &bc1, const Boundary_Condition &bc2) {
+    return visit(
+        []<class U, class V>(const U &bc1, const V &bc2) {
+          if constexpr (same_as<U, V>) {
+            return bc1 == bc2;
+          } else {
+            return false;
+          }
+        },
+        bc1,
+        bc2);
+  }
+
+  //
+  // ... Wall
+  //
+  Wall::Wall(Boundary_ID boundary)
+      : boundary_{boundary} {}
+
+  bool
+  operator==(const Wall &wall1, const Wall &wall2) {
+    return wall1.boundary_ == wall2.boundary_;
+  }
+
+  Boundary_ID
+  Wall::boundary() const {
+    return boundary_;
+  }
+
+  json
+  Wall::get_json() const {
+    json j = json::object();
+    j["wall"] = json::object();
+    j["wall"]["boundary"] = boundary_;
+    return j;
+  }
+
+  void
+  Wall::set_json(const json &j) {
+    boundary_ = j["wall"]["boundary"];
+  }
+
+  //
+  // ... Symmetry
+  //
+  Symmetry::Symmetry(Boundary_ID boundary)
+      : boundary_{boundary} {}
+
+  bool
+  operator==(const Symmetry &symmetry1, const Symmetry &symmetry2) {
+    return symmetry1.boundary_ == symmetry2.boundary_;
+  }
+
+  bool
+  operator!=(const Symmetry &symmetry1, const Symmetry &symmetry2) {
+    return !(symmetry1 == symmetry2);
+  }
+
+  Boundary_ID
+  Symmetry::boundary() const {
+    return boundary_;
+  }
+
+  json
+  Symmetry::get_json() const {
+    json j = json::object();
+    j["symmetry"] = boundary_;
+    return j;
+  }
+
+  void
+  Symmetry::set_json(const json &j) {
+    boundary_ = j["symmetry"];
+  }
+
+  //
+  // ... Inlet
+  //
+
+  Inlet::Inlet(Boundary_ID boundary, double inlet_speed)
+      : boundary_{boundary}
+      , inlet_speed_{inlet_speed} {}
+
+  bool
+  operator==(const Inlet &inlet1, const Inlet &inlet2) {
+    return inlet1.boundary_ == inlet2.boundary_ && inlet1.inlet_speed_ == inlet2.inlet_speed_;
+  }
+
+  bool
+  operator!=(const Inlet &inlet1, const Inlet &inlet2) {
+    return !(inlet1 == inlet2);
+  }
+
+  Boundary_ID
+  Inlet::boundary() const {
+    return boundary_;
+  }
+
+  json
+  Inlet::get_json() const {
+    json j = json::object();
+    j["inlet"]["boundary"] = boundary_;
+    j["inlet"]["inletSpeed"] = inlet_speed_;
+    return j;
+  }
+
+  void
+  Inlet::set_json(const json &j) {
+    boundary_ = j["inlet"]["boundary"];
+    inlet_speed_ = j["inlet"]["inletSpeed"];
+  }
+
+  //
+  // ... Outlet
+  //
+
+  Outlet::Outlet(Boundary_ID boundary, double outlet_speed)
+      : boundary_{boundary}
+      , outlet_speed_{outlet_speed} {}
+
+  bool
+  operator==(const Outlet &outlet1, const Outlet &outlet2) {
+    return outlet1.boundary_ == outlet2.boundary_ && outlet1.outlet_speed_ == outlet2.outlet_speed_;
+  }
+
+  bool
+  operator!=(const Outlet &outlet1, const Outlet &outlet2) {
+    return !(outlet1 == outlet2);
+  }
+
+  Boundary_ID
+  Outlet::boundary() const {
+    return boundary_;
+  }
+
+  json
+  Outlet::get_json() const {
+    json j = json::object();
+    j["outlet"] = json::object();
+    j["outlet"]["boundary"] = boundary_;
+    j["outlet"]["outletSpeed"] = outlet_speed_;
+    return j;
+  }
+
+  void
+  Outlet::set_json(const json &j) {
+    boundary_ = j["outlet"]["boundary"];
+    outlet_speed_ = j["outlet"]["outletSpeed"];
+  }
+
+  //
+  // ... Pressure_Drop
+
+  Pressure_Drop::Pressure_Drop(Boundary_ID boundary, double value)
+      : boundary_(boundary)
+      , value_(value) {}
+
+  bool
+  operator==(const Pressure_Drop &pressure_drop1, const Pressure_Drop &pressure_drop2) {
+    return pressure_drop1.boundary_ == pressure_drop2.boundary_ &&
+           pressure_drop1.value_ == pressure_drop2.value_;
+  }
+
+  bool
+  operator!=(const Pressure_Drop &pressure_drop1, const Pressure_Drop &pressure_drop2) {
+    return !(pressure_drop1 == pressure_drop2);
+  }
+
+  Boundary_ID
+  Pressure_Drop::boundary() const {
+    return boundary_;
+  }
+
+  json
+  Pressure_Drop::get_json() const {
+    json j = json::object();
+    j["pressureDrop"] = json::object();
+    j["pressureDrop"]["boundary"] = boundary_;
+    j["pressureDrop"]["value"] = value_;
+    return j;
+  }
+
+  void
+  Pressure_Drop::set_json(const json &j) {
+    boundary_ = j["pressureDrop"]["boundary"];
+    value_ = j["pressureDrop"]["value"];
+  }
+
+} // end of namespace lbm::core

--- a/cxx/lbm/core/Boundary_Condition.hpp
+++ b/cxx/lbm/core/Boundary_Condition.hpp
@@ -11,27 +11,20 @@ namespace lbm::core {
   class Wall final : public JSON_Convertible {
   public:
     Wall() = default;
-    Wall(Boundary_ID boundary)
-        : boundary_{boundary} {}
+    Wall(Boundary_ID boundary);
 
     friend bool
-    operator==(const Wall &wall1, const Wall &wall2) {
-      return wall1.boundary_ == wall2.boundary_;
-    }
+    operator==(const Wall &wall1, const Wall &wall2);
+
+    Boundary_ID
+    boundary() const;
 
   private:
     json
-    get_json() const override {
-      json j = json::object();
-      j["wall"] = json::object();
-      j["wall"]["boundary"] = boundary_;
-      return j;
-    }
+    get_json() const override;
 
     void
-    set_json(const json &j) override {
-      boundary_ = j["wall"]["boundary"];
-    }
+    set_json(const json &j) override;
 
     Boundary_ID boundary_{};
   };
@@ -39,31 +32,23 @@ namespace lbm::core {
   class Symmetry final : public JSON_Convertible {
   public:
     Symmetry() = default;
-    Symmetry(Boundary_ID boundary)
-        : boundary_{boundary} {}
+    Symmetry(Boundary_ID boundary);
 
     friend bool
-    operator==(const Symmetry &symmetry1, const Symmetry &symmetry2) {
-      return symmetry1.boundary_ == symmetry2.boundary_;
-    }
+    operator==(const Symmetry &symmetry1, const Symmetry &symmetry2);
 
     friend bool
-    operator!=(const Symmetry &symmetry1, const Symmetry &symmetry2) {
-      return !(symmetry1 == symmetry2);
-    }
+    operator!=(const Symmetry &symmetry1, const Symmetry &symmetry2);
+
+    Boundary_ID
+    boundary() const;
 
   private:
     json
-    get_json() const override {
-      json j = json::object();
-      j["symmetry"] = boundary_;
-      return j;
-    }
+    get_json() const override;
 
     void
-    set_json(const json &j) override {
-      boundary_ = j["symmetry"];
-    }
+    set_json(const json &j) override;
 
     Boundary_ID boundary_;
   };
@@ -71,34 +56,23 @@ namespace lbm::core {
   class Inlet final : public JSON_Convertible {
   public:
     Inlet() = default;
-    Inlet(Boundary_ID boundary, double inlet_speed)
-        : boundary_{boundary}
-        , inlet_speed_{inlet_speed} {}
+    Inlet(Boundary_ID boundary, double inlet_speed);
 
     friend bool
-    operator==(const Inlet &inlet1, const Inlet &inlet2) {
-      return inlet1.boundary_ == inlet2.boundary_ && inlet1.inlet_speed_ == inlet2.inlet_speed_;
-    }
+    operator==(const Inlet &inlet1, const Inlet &inlet2);
 
     friend bool
-    operator!=(const Inlet &inlet1, const Inlet &inlet2) {
-      return !(inlet1 == inlet2);
-    }
+    operator!=(const Inlet &inlet1, const Inlet &inlet2);
+
+    Boundary_ID
+    boundary() const;
 
   private:
     json
-    get_json() const override {
-      json j = json::object();
-      j["inlet"]["boundary"] = boundary_;
-      j["inlet"]["inletSpeed"] = inlet_speed_;
-      return j;
-    }
+    get_json() const override;
 
     void
-    set_json(const json &j) override {
-      boundary_ = j["inlet"]["boundary"];
-      inlet_speed_ = j["inlet"]["inletSpeed"];
-    }
+    set_json(const json &j) override;
 
     Boundary_ID boundary_{};
     double inlet_speed_{};
@@ -107,35 +81,23 @@ namespace lbm::core {
   class Outlet final : public JSON_Convertible {
   public:
     Outlet() = default;
-    Outlet(Boundary_ID boundary, double outlet_speed)
-        : boundary_{boundary}
-        , outlet_speed_{outlet_speed} {}
+    Outlet(Boundary_ID boundary, double outlet_speed);
 
     friend bool
-    operator==(const Outlet &outlet1, const Outlet &outlet2) {
-      return outlet1.boundary_ == outlet2.boundary_ &&
-             outlet1.outlet_speed_ == outlet2.outlet_speed_;
-    }
+    operator==(const Outlet &outlet1, const Outlet &outlet2);
+
     friend bool
-    operator!=(const Outlet &outlet1, const Outlet &outlet2) {
-      return !(outlet1 == outlet2);
-    }
+    operator!=(const Outlet &outlet1, const Outlet &outlet2);
+
+    Boundary_ID
+    boundary() const;
 
   private:
     json
-    get_json() const override {
-      json j = json::object();
-      j["outlet"] = json::object();
-      j["outlet"]["boundary"] = boundary_;
-      j["outlet"]["outletSpeed"] = outlet_speed_;
-      return j;
-    }
+    get_json() const override;
 
     void
-    set_json(const json &j) override {
-      boundary_ = j["outlet"]["boundary"];
-      outlet_speed_ = j["outlet"]["outletSpeed"];
-    }
+    set_json(const json &j) override;
 
     Boundary_ID boundary_{};
     double outlet_speed_{};
@@ -144,36 +106,23 @@ namespace lbm::core {
   class Pressure_Drop final : public JSON_Convertible {
   public:
     Pressure_Drop() = default;
-    Pressure_Drop(Boundary_ID boundary, double value)
-        : boundary_(boundary)
-        , value_(value) {}
+    Pressure_Drop(Boundary_ID boundary, double value);
 
     friend bool
-    operator==(const Pressure_Drop &pressure_drop1, const Pressure_Drop &pressure_drop2) {
-      return pressure_drop1.boundary_ == pressure_drop2.boundary_ &&
-             pressure_drop1.value_ == pressure_drop2.value_;
-    }
+    operator==(const Pressure_Drop &pressure_drop1, const Pressure_Drop &pressure_drop2);
 
     friend bool
-    operator!=(const Pressure_Drop &pressure_drop1, const Pressure_Drop &pressure_drop2) {
-      return !(pressure_drop1 == pressure_drop2);
-    }
+    operator!=(const Pressure_Drop &pressure_drop1, const Pressure_Drop &pressure_drop2);
+
+    Boundary_ID
+    boundary() const;
 
   private:
     json
-    get_json() const override {
-      json j = json::object();
-      j["pressureDrop"] = json::object();
-      j["pressureDrop"]["boundary"] = boundary_;
-      j["pressureDrop"]["value"] = value_;
-      return j;
-    }
+    get_json() const override;
 
     void
-    set_json(const json &j) override {
-      boundary_ = j["pressureDrop"]["boundary"];
-      value_ = j["pressureDrop"]["value"];
-    }
+    set_json(const json &j) override;
 
     Boundary_ID boundary_{};
     double value_{};
@@ -186,50 +135,23 @@ namespace lbm::core {
 
     Boundary_Condition() = default;
 
-    friend void
-    to_json(json &j, const Boundary_Condition &boundary_condition) {
-      visit([&](const auto &boundary_condition) { j = boundary_condition; }, boundary_condition);
-    }
+    Boundary_ID
+    boundary() const;
 
     friend void
-    from_json(const json &j, Boundary_Condition &boundary_condition) {
-      if (j.contains("wall")) {
-        boundary_condition = Wall(j);
-      } else if (j.contains("symmetry")) {
-        boundary_condition = Symmetry(j);
-      } else if (j.contains("inlet")) {
-        boundary_condition = Inlet(j);
-      } else if (j.contains("outlet")) {
-        boundary_condition = Outlet(j);
-      } else if (j.contains("pressureDrop")) {
-        boundary_condition = Pressure_Drop(j);
-      }
-    }
+    to_json(json &j, const Boundary_Condition &boundary_condition);
+
+    friend void
+    from_json(const json &j, Boundary_Condition &boundary_condition);
 
     friend ostream &
-    operator<<(ostream &os, const Boundary_Condition &boundary_condition) {
-      return os << json(boundary_condition);
-    }
+    operator<<(ostream &os, const Boundary_Condition &boundary_condition);
 
     friend istream &
-    operator>>(istream &is, Boundary_Condition &boundary_condition) {
-      boundary_condition = json::parse(is);
-      return is;
-    }
+    operator>>(istream &is, Boundary_Condition &boundary_condition);
 
     friend bool
-    operator==(const Boundary_Condition &bc1, const Boundary_Condition &bc2) {
-      return visit(
-          []<class U, class V>(const U &bc1, const V &bc2) {
-            if constexpr (same_as<U, V>) {
-              return bc1 == bc2;
-            } else {
-              return false;
-            }
-          },
-          bc1,
-          bc2);
-    }
+    operator==(const Boundary_Condition &bc1, const Boundary_Condition &bc2);
   };
 
   class Boundary_Conditions
@@ -241,19 +163,10 @@ namespace lbm::core {
 
   private:
     json
-    get_json() const override {
-      json j = static_cast<const Base &>(*this);
-      return j;
-    }
+    get_json() const override;
 
     void
-    set_json(const json &j) override {
-      Base::clear();
-      transform(std::begin(j),
-                std::end(j),
-                back_inserter(*this),
-                [](const json &bc) -> Boundary_Condition { return bc; });
-    }
+    set_json(const json &j) override;
   };
 
 } // end of namespace lbm::core

--- a/cxx/lbm/core/Input.hpp
+++ b/cxx/lbm/core/Input.hpp
@@ -59,6 +59,9 @@ namespace lbm::core {
     double
     lattice_spacing() const;
 
+    Boundary_Condition
+    boundary(Boundary_ID id) const;
+
     friend bool
     operator==(const Input &inp0, const Input &inp1);
 

--- a/test/cxx/boundary_condition_test.cpp
+++ b/test/cxx/boundary_condition_test.cpp
@@ -16,7 +16,9 @@
 namespace lbm::core {
   TEST_CASE("Boundary Condition") {
     SECTION("Wall") {
-      Boundary_Condition boundary_condition{Wall{Boundary_ID{Boundary::Lower, Boundary::NA}}};
+      Boundary_ID west = Boundary_ID{Boundary::Lower, Boundary::NA};
+      Boundary_Condition boundary_condition{Wall{west}};
+
       SECTION("Conversion to and from json") {
         json json_boundary_condition = boundary_condition;
         Boundary_Condition boundary_condition_from_json = json_boundary_condition;
@@ -29,10 +31,13 @@ namespace lbm::core {
         ss >> boundary_condition_from_text;
         CHECK(boundary_condition_from_text == boundary_condition);
       }
+
+      SECTION("Boundary ID access") { CHECK(boundary_condition.boundary() == west); }
     }
 
     SECTION("Symmetry") {
-      Boundary_Condition boundary_condition{Symmetry{Boundary_ID{Boundary::NA, Boundary::Upper}}};
+      Boundary_ID north = Boundary_ID{Boundary::NA, Boundary::Upper};
+      Boundary_Condition boundary_condition{Symmetry{north}};
       SECTION("Conversion to and from json") {
         json json_boundary_condition = boundary_condition;
         std::cout << json_boundary_condition << std::endl;
@@ -46,10 +51,12 @@ namespace lbm::core {
         ss >> boundary_condition_from_text;
         CHECK(boundary_condition_from_text == boundary_condition);
       }
+      SECTION("Boundary ID access") { CHECK(boundary_condition.boundary() == north); }
     }
 
     SECTION("Inlet") {
-      Boundary_Condition boundary_condition{Inlet{Boundary_ID{Boundary::NA, Boundary::Lower}, 3.0}};
+      Boundary_ID south = Boundary_ID{Boundary::NA, Boundary::Lower};
+      Boundary_Condition boundary_condition{Inlet{south, 3.0}};
       SECTION("Conversion to and from json") {
         json json_boundary_condition = boundary_condition;
         std::cout << json_boundary_condition << std::endl;
@@ -63,9 +70,11 @@ namespace lbm::core {
         ss >> boundary_condition_from_text;
         CHECK(boundary_condition_from_text == boundary_condition);
       }
+      SECTION("Boundary ID access") { CHECK(boundary_condition.boundary() == south); }
     }
 
     SECTION("Outlet") {
+      Boundary_ID south = Boundary_ID{Boundary::NA, Boundary::Lower};
       Boundary_Condition boundary_condition{
           Outlet{Boundary_ID{Boundary::NA, Boundary::Lower}, 3.0}};
       SECTION("Conversion to and from json") {
@@ -80,11 +89,12 @@ namespace lbm::core {
         ss >> boundary_condition_from_text;
         CHECK(boundary_condition_from_text == boundary_condition);
       }
+      SECTION("Boundary ID access") { CHECK(boundary_condition.boundary() == south); }
     }
 
     SECTION("Pressure Drop") {
-      Boundary_Condition boundary_condition{
-          Pressure_Drop{Boundary_ID{Boundary::Upper, Boundary::NA}, 3.0}};
+      Boundary_ID east = Boundary_ID{Boundary::Upper, Boundary::NA};
+      Boundary_Condition boundary_condition{Pressure_Drop{east, 3.0}};
       SECTION("Conversion to and from json") {
         json json_boundary_condition = boundary_condition;
         Boundary_Condition boundary_condition_from_json = json_boundary_condition;


### PR DESCRIPTION
Problem:
- Boundary conditions are concrete, but are implemented only in header files which slows recompilation.
- Boundary conditions do not provide access to the bounary ID.

Solution:
- Move the boundary condition functions to an implementation file.
- Add acces to the boundary condition ID.