### PR TITLE
:bug: :wrench: User preset configuration

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -27,14 +27,14 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         build_type: [Release]
-        c_compiler: [gcc, clang]
+        c_compiler: [gcc, clang-15]
         include:
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
           - os: ubuntu-latest
-            c_compiler: clang
-            cpp_compiler: clang++
+            c_compiler: clang-15
+            cpp_compiler: clang++-15
 
     steps:
     - uses: actions/checkout@v4
@@ -49,6 +49,7 @@ jobs:
       run : |
         sudo apt-get update
         sudo apt-get install libboost-program-options-dev
+        sudo apt-get install clang-15
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.30)
 
 option(lbmbench_BUILD_TESTING "Build the lbmbench tests" ON)
+option(lbmbench_BUILD_EXAMPLES "Build the lbmbench examples" OFF)
+
 option(lbmbench_USE_MPI "Build LBM benchmarks with MPI support" OFF)
 option(lbmbench_USE_THREADS "Build LBM benchmarks with multithreading support" OFF)
 option(lbmbench_USE_OPENMP "Build LBM benchmarks with OpenMP support" OFF)
@@ -14,6 +16,8 @@ option(lbmbench_USE_BFLOAT16 "Build LBM benchmarks with bfloat16 support" ON)
 option(lbmbench_USE_FIXED64 "Build LBM benchmarks with 64bit fixed-point support" ON)
 option(lbmbench_USE_FIXED32 "Build LBM benchmarks with 32bit fixed-point support" ON)
 option(lbmbench_USE_FIXED16 "Build LBM benchmarks with 16bit fixed-point support" ON)
+
+option(lbmbench_USE_VTK "Build LBM visualization with VTK" ON)
 
 if(lbmbench_USE_CUDA)
   project(lbmbench VERSION 0.1.0 LANGUAGES C CXX CUDA)
@@ -43,6 +47,10 @@ if(lbmbench_BUILD_TESTING)
   if(BUILD_TESTING)
     add_subdirectory(test)
   endif()
+endif()
+
+if(lbmbench_BUILD_EXAMPLES)
+  add_subdirectory(examples)
 endif()
 
 install(EXPORT lbmbench_EXPORTS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-set(lbmbench_CXX_FEATURES cxx_std_20)
+set(lbmbench_CXX_FEATURES cxx_std_23)
 
 include(GNUInstallDirs)
 set(lbmbench_INSTALL_BINDIR ${CMAKE_INSTALL_BINDIR})

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,6 +15,7 @@
                 "CMAKE_CXX_FLAGS_RELEASE" : "-DNDEBUG -O3",
 		"CMAKE_CXX_FLAGS_RELWITHDEBINFO" : "-fsanitize=undefined -fsanitize=address -g -O3",
 		"CMAKE_EXPORT_COMPILE_COMMANDS" : "ON",
+                "lbmbench_BUILD_EXAMPLES" : "OFF",
                 "nlohmann_json_GIT_TAG" : "v3.10.0",
                 "nlohmann_json_FORCE_DOWNLOAD" : true,
                 "nlohmann_json_schema_validator_FORCE_DOWNLOAD" : true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 LBM Bench
 =========
 
+
+
+
 ## About 
 Benchmarks comparing the performance of verious optimization and
 acceleration techniques to the Lattice Boltzmann Method (LBM).
 
+## Compiler Compatability
+ - gcc 11 and latere
+ - clang 15 and later

--- a/cmake/lbmbench_deps.cmake
+++ b/cmake/lbmbench_deps.cmake
@@ -22,14 +22,20 @@ find_package(nlohmann_json_schema_validator REQUIRED)
 
 find_package(Boost REQUIRED COMPONENTS program_options)
 
-if(lbm_USE_MPI)
+if(lbmbench_USE_MPI)
   find_package(MPI REQUIRED)
 endif()
 
-if(lbm_USE_THREADS)
+if(lbmbench_USE_THREADS)
   find_package(Threads REQUIRED)
 endif()
 
-if(lbm_USE_OPENMP)
+if(lbmbench_USE_OPENMP)
   find_package(OpenMP REQUIRED)
+endif()
+
+if(lbmbench_BUILD_EXAMPLES)
+  if(lbmbench_USE_VTK)
+    find_package(VTK REQUIRED)
+  endif()
 endif()

--- a/compilers-example.json
+++ b/compilers-example.json
@@ -2,26 +2,26 @@
     {
         "name" : "gcc-10",
         "root" : "/usr",
-        "cc" : "gcc-10",
-        "cxx" : "g++-10"
+        "cc" : "/usr/bin/gcc-10",
+        "cxx" : "/usr/bin/g++-10"
     },
     {
         "name" : "gcc-11",
         "root" : "/usr",
-        "cc" : "gcc-11",
-        "cxx" : "g++-11"
+        "cc" : "/usr/bin/gcc-11",
+        "cxx" : "/usr/bin/g++-11"
     },
     {
         "name" : "gcc-12",
         "root" : "/usr",
-        "cc" : "gcc-12",
-        "cxx" : "g++-12"
+        "cc" : "/usr/bin/gcc-12",
+        "cxx" : "/usr/bin/g++-12"
     },
     {
         "name" : "gcc-13",
         "root" : "$penv{HOME}/.local/opt/gcc/13.3.0",
-        "cc" : "gcc",
-        "cxx" : "g++"
+        "cc" : "/home/sbj/.local/opt/gcc/13.3.0/bin/gcc",
+        "cxx" : "/home/sbj/.local/opt/gcc/13.3.0/bin/g++"
     },
     {
         "name" : "clang-11",
@@ -32,38 +32,25 @@
     {
         "name" : "clang-12",
         "root" : "/usr",
-        "cc" : "clang-12",
-        "cxx" : "clang++-12"
+        "cc" : "/usr/bin/clang-12",
+        "cxx" : "/usr/bin/clang++-12"
     },
     {
         "name" : "clang-13",
         "root" : "/usr",
-        "cc" : "clang-13",
-        "cxx" : "clang++-13"
+        "cc" : "/usr/bin/clang-13",
+        "cxx" : "/usr/bin/clang++-13"
     },
     {
         "name" : "clang-14",
         "root" : "/usr",
-        "cc" : "clang-14",
-        "cxx" : "clang++-14"
+        "cc" : "/usr/bin/clang-14",
+        "cxx" : "/usr/bin/clang++-14"
     },
     {
         "name" : "clang-15",
         "root" : "/usr",
-        "cc" : "clang-15",
-        "cxx" : "clang++-15"
-    },
-    {
-        "name" : "clang-17",
-        "root" : "$penv{HOME}/.local/opt/llvm/17.0.6",
-        "cc" : "clang",
-        "cxx" : "clang++"
-    },
-    {
-        "name" : "clang-18",
-        "root" : "$penv{HOME}/.local/opt/llvm/18.1.4",
-        "cc" : "clang",
-        "cxx" : "clang++"
+        "cc" : "/usr/bin/clang-15",
+        "cxx" : "/usr/bin/clang++-15"
     }
-
 ]

--- a/cxx/CMakeLists.txt
+++ b/cxx/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(lbmbench_library
   lbm/core/Float_Type.cpp
   lbm/core/Kernel.cpp
   lbm/core/Input.cpp
+  lbm/core/subdomain_tags.cpp
   lbm/app/Runtime_Config.cpp
   lbm/app/Runtime_Config_Impl.cpp
   lbm/app/Driver.cpp

--- a/cxx/lbm/D2Q9/State.hpp
+++ b/cxx/lbm/D2Q9/State.hpp
@@ -39,6 +39,7 @@ namespace lbm::D2Q9 {
 
       initialize_nodes(input);
       initialize_bounceback_lists();
+      initialize_boundary_functions(input);
     }
 
     void
@@ -124,7 +125,94 @@ namespace lbm::D2Q9 {
     }
 
     void
-    reset_boundaries() {}
+    initialize_boundary_functions(Input input) {
+      using enum Boundary_ID;
+      boundary_functions_[Left] = make_left_boundary_function(input);
+      boundary_functions_[Right] = make_right_boundary_function(input);
+      boundary_functions_[Bottom] = make_left_boundary_function(input);
+      boundary_functions_[Top] = make_left_boundary_function(input);
+    }
+
+    function<void()>
+    make_left_boundary_function(Input input) {
+      Boundary_Condition bc = input.boundary(Boundary_ID::Left);
+      if (holds_alternative<Wall>(bc)) {
+        return [] {};
+      } else if (holds_alternative<Symmetry>(bc)) {
+        return [] {};
+      } else if (holds_alternative<Inlet>(bc)) {
+        return [] {};
+      } else if (holds_alternative<Outlet>(bc)) {
+        return [] {};
+      } else if (holds_alternative<Pressure_Drop>(bc)) {
+        return [] {};
+      } else {
+        unreachable_code(source_location::current());
+      }
+    }
+
+    function<void()>
+    make_right_boundary_function(Input input) {
+      Boundary_Condition bc = input.boundary(Boundary_ID::Right);
+      if (holds_alternative<Wall>(bc)) {
+        return [] {};
+      } else if (holds_alternative<Symmetry>(bc)) {
+        return [] {};
+      } else if (holds_alternative<Inlet>(bc)) {
+        return [] {};
+      } else if (holds_alternative<Outlet>(bc)) {
+        return [] {};
+      } else if (holds_alternative<Pressure_Drop>(bc)) {
+        return [] {};
+      } else {
+        unreachable_code(source_location::current());
+      }
+    }
+
+    function<void()>
+    make_bottom_boundary_function(Input input) {
+      Boundary_Condition bc = input.boundary(Boundary_ID::Bottom);
+      if (holds_alternative<Wall>(bc)) {
+        return [] {};
+      } else if (holds_alternative<Symmetry>(bc)) {
+        return [] {};
+      } else if (holds_alternative<Inlet>(bc)) {
+        return [] {};
+      } else if (holds_alternative<Outlet>(bc)) {
+        return [] {};
+      } else if (holds_alternative<Pressure_Drop>(bc)) {
+        return [] {};
+      } else {
+        unreachable_code(source_location::current());
+      }
+    }
+
+    function<void()>
+    make_top_boundary_function(Input input) {
+      Boundary_Condition bc = input.boundary(Boundary_ID::Top);
+      if (holds_alternative<Wall>(bc)) {
+        return [] {};
+      } else if (holds_alternative<Symmetry>(bc)) {
+        return [] {};
+      } else if (holds_alternative<Inlet>(bc)) {
+        return [] {};
+      } else if (holds_alternative<Outlet>(bc)) {
+        return [] {};
+      } else if (holds_alternative<Pressure_Drop>(bc)) {
+        return [] {};
+      } else {
+        unreachable_code(source_location::current());
+      }
+    }
+
+    void
+    reset_boundaries() {
+      using enum Boundary_ID;
+      boundary_functions_[Left]();
+      boundary_functions_[Right]();
+      boundary_functions_[Bottom]();
+      boundary_functions_[Top]();
+    }
 
     size_type
     current_time_index() const {
@@ -173,6 +261,7 @@ namespace lbm::D2Q9 {
       nodes_[time_step_ % 2] = j["nodes"];
       nodes_[(time_step_ + 1) % 2] = j["nodes"];
     }
+
     size_type nx_{};
     size_type ny_{};
     size_type nxm1_{};
@@ -183,6 +272,7 @@ namespace lbm::D2Q9 {
     Time_Step time_step_{};
     Obstacle_List obstacles_{};
     Bounceback_Lists bounceback_lists_{};
+    unordered_map<Boundary_ID, function<void()>> boundary_functions_{};
   };
 
 } // end of namespace lbm::D2Q9

--- a/cxx/lbm/D2Q9/Velocity_Distribution.hpp
+++ b/cxx/lbm/D2Q9/Velocity_Distribution.hpp
@@ -67,12 +67,12 @@ namespace lbm::D2Q9 {
       return storage_(i + 1, j + 1);
     }
 
-    friend bool
+    friend constexpr bool
     operator==(const Velocity_Distribution &vd1, const Velocity_Distribution &vd2) {
       return vd1.storage_ == vd2.storage_;
     }
 
-    friend bool
+    friend constexpr bool
     operator!=(const Velocity_Distribution &vd1, const Velocity_Distribution &vd2) {
       return !(vd1 == vd2);
     }
@@ -96,6 +96,11 @@ namespace lbm::D2Q9 {
     constexpr Velocity
     velocity() const {
       return momentum() / density();
+    }
+
+    constexpr Velocity_Distribution
+    nonequilibrium() const {
+      return equilibrium(density(), velocity()) - *this;
     }
 
     void
@@ -241,6 +246,36 @@ namespace lbm::D2Q9 {
     friend constexpr Velocity_Distribution
     operator/(const Velocity_Distribution &f, Value_Type s) {
       return Velocity_Distribution{f.storage_ / s};
+    }
+
+    auto
+    begin() {
+      return storage_.begin();
+    }
+
+    auto
+    end() {
+      return storage_.end();
+    }
+
+    auto
+    begin() const {
+      return storage_.begin();
+    }
+
+    auto
+    end() const {
+      return storage_.end();
+    }
+
+    auto
+    cbegin() const {
+      return begin();
+    }
+
+    auto
+    cend() const {
+      return end();
     }
 
   private:

--- a/cxx/lbm/D2Q9/Velocity_Distribution.hpp
+++ b/cxx/lbm/D2Q9/Velocity_Distribution.hpp
@@ -18,7 +18,7 @@ namespace lbm::D2Q9 {
     using Reference = T &;
     using Const_Reference = const T &;
     using Density = Value_Type;
-    using Storage = Fixed_Array<Value_Type, Fixed_Lexical<3, 3>>;
+    using Storage = Fixed_MD_Array<Value_Type, Fixed_Lexical<3, 3>>;
     using Velocity = Fixed_Euclidean<Value_Type, 2>;
     using Momentum = Fixed_Euclidean<Value_Type, 2>;
 
@@ -31,7 +31,7 @@ namespace lbm::D2Q9 {
     static constexpr T three_halves = T(3) / T(2);
 
     // clang-format off
-    static constexpr Fixed_Array<T, Fixed_Lexical<3,3>> weights = {
+    static constexpr Fixed_MD_Array<T, Fixed_Lexical<3,3>> weights = {
       one_36th, one_9th,   one_36th,
       one_9th,  four_9ths, one_9th,
       one_36th, one_9th,   one_36th
@@ -39,7 +39,7 @@ namespace lbm::D2Q9 {
     // clang-format on
 
     // clang-format off
-    static constexpr  Fixed_Array<Velocity, Fixed_Lexical<3, 3>>
+    static constexpr  Fixed_MD_Array<Velocity, Fixed_Lexical<3, 3>>
     discrete_velocities =
     {Velocity{-1, -1}, Velocity{0, -1}, Velocity{1, -1},
      Velocity{-1,  0}, Velocity{0,  0}, Velocity{1,  0},

--- a/cxx/lbm/D2Q9/import.hpp
+++ b/cxx/lbm/D2Q9/import.hpp
@@ -32,14 +32,13 @@
 #include <vector>
 
 namespace lbm::D2Q9 {
-  using lbm::core::Array;
   using lbm::core::Boundary_Condition;
   using lbm::core::Boundary_ID;
-  using lbm::core::Dynamic_Array;
+  using lbm::core::Dynamic_MD_Array;
   using lbm::core::Euclidean;
-  using lbm::core::Fixed_Array;
   using lbm::core::Fixed_Euclidean;
   using lbm::core::Fixed_Lexical;
+  using lbm::core::Fixed_MD_Array;
   using lbm::core::I_State;
   using lbm::core::Inlet;
   using lbm::core::Input;
@@ -47,6 +46,7 @@ namespace lbm::D2Q9 {
   using lbm::core::json;
   using lbm::core::JSON_Convertible;
   using lbm::core::Lexical;
+  using lbm::core::MD_Array;
   using lbm::core::Outlet;
   using lbm::core::Pressure_Drop;
   using lbm::core::Shape;

--- a/cxx/lbm/D2Q9/import.hpp
+++ b/cxx/lbm/D2Q9/import.hpp
@@ -17,6 +17,7 @@
 #include <lbm/core/Shape.hpp>
 #include <lbm/core/base_types.hpp>
 #include <lbm/core/misc.hpp>
+#include <lbm/core/subdomain_tags.hpp>
 #include <lbm/exceptions/Unreachable.hpp>
 
 //
@@ -32,6 +33,16 @@
 #include <vector>
 
 namespace lbm::D2Q9 {
+  using lbm::core::Bottom;
+  using lbm::core::bottom;
+  using lbm::core::Boundary_Tag2;
+  using lbm::core::Left;
+  using lbm::core::left;
+  using lbm::core::Right;
+  using lbm::core::right;
+  using lbm::core::Top;
+  using lbm::core::top;
+
   using lbm::core::Boundary_Condition;
   using lbm::core::Boundary_ID;
   using lbm::core::Dynamic_MD_Array;

--- a/cxx/lbm/D2Q9/import.hpp
+++ b/cxx/lbm/D2Q9/import.hpp
@@ -4,6 +4,8 @@
 // ... LBM Bench header files
 //
 #include <lbm/core/Array.hpp>
+#include <lbm/core/Boundary_Condition.hpp>
+#include <lbm/core/Boundary_ID.hpp>
 #include <lbm/core/Dynamic_Array.hpp>
 #include <lbm/core/Euclidean.hpp>
 #include <lbm/core/Fixed_Array.hpp>
@@ -15,6 +17,7 @@
 #include <lbm/core/Shape.hpp>
 #include <lbm/core/base_types.hpp>
 #include <lbm/core/misc.hpp>
+#include <lbm/exceptions/Unreachable.hpp>
 
 //
 // ... Standard header files
@@ -22,33 +25,49 @@
 #include <algorithm>
 #include <array>
 #include <concepts>
+#include <functional>
+#include <source_location>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
 namespace lbm::D2Q9 {
   using lbm::core::Array;
+  using lbm::core::Boundary_Condition;
+  using lbm::core::Boundary_ID;
   using lbm::core::Dynamic_Array;
   using lbm::core::Euclidean;
   using lbm::core::Fixed_Array;
   using lbm::core::Fixed_Euclidean;
   using lbm::core::Fixed_Lexical;
   using lbm::core::I_State;
+  using lbm::core::Inlet;
   using lbm::core::Input;
   using lbm::core::integer;
   using lbm::core::json;
   using lbm::core::JSON_Convertible;
   using lbm::core::Lexical;
+  using lbm::core::Outlet;
+  using lbm::core::Pressure_Drop;
   using lbm::core::Shape;
   using lbm::core::size_type;
   using lbm::core::sqr;
+  using lbm::core::Symmetry;
   using lbm::core::unroll_horizontally;
+  using lbm::core::Wall;
+
+  using lbm::exceptions::unreachable_code;
 
   using std::array;
   using std::copy;
   using std::for_each;
+  using std::function;
+  using std::holds_alternative;
   using std::index_sequence;
   using std::make_index_sequence;
   using std::same_as;
+  using std::source_location;
+  using std::unordered_map;
   using std::vector;
 
 } // end of namespace lbm::D2Q9

--- a/cxx/lbm/D2Q9/import.hpp
+++ b/cxx/lbm/D2Q9/import.hpp
@@ -4,6 +4,7 @@
 // ... LBM Bench header files
 //
 #include <lbm/core/Array.hpp>
+#include <lbm/core/Array2.hpp>
 #include <lbm/core/Boundary_Condition.hpp>
 #include <lbm/core/Boundary_ID.hpp>
 #include <lbm/core/Dynamic_Array.hpp>
@@ -16,6 +17,7 @@
 #include <lbm/core/Lexical.hpp>
 #include <lbm/core/Shape.hpp>
 #include <lbm/core/base_types.hpp>
+#include <lbm/core/forall.hpp>
 #include <lbm/core/misc.hpp>
 #include <lbm/core/subdomain_tags.hpp>
 #include <lbm/exceptions/Unreachable.hpp>
@@ -36,6 +38,8 @@ namespace lbm::D2Q9 {
   using lbm::core::Bottom;
   using lbm::core::bottom;
   using lbm::core::Boundary_Tag2;
+  using lbm::core::Interior;
+  using lbm::core::interior;
   using lbm::core::Left;
   using lbm::core::left;
   using lbm::core::Right;
@@ -43,6 +47,7 @@ namespace lbm::D2Q9 {
   using lbm::core::Top;
   using lbm::core::top;
 
+  using lbm::core::Array2;
   using lbm::core::Boundary_Condition;
   using lbm::core::Boundary_ID;
   using lbm::core::Dynamic_MD_Array;

--- a/cxx/lbm/core/Array.hpp
+++ b/cxx/lbm/core/Array.hpp
@@ -9,7 +9,7 @@
 namespace lbm::core {
 
   template <class T, size_type N, class Order_Type = Lexical<N>>
-  class Array {
+  class MD_Array {
 
   public:
     using value_type = T;
@@ -22,13 +22,13 @@ namespace lbm::core {
 
     using Order = Order_Type;
 
-    Array() = default;
-    Array(Order order, T init = T{})
+    MD_Array() = default;
+    MD_Array(Order order, T init = T{})
         : order_{std::move(order)}
         , values_(order_.total_size(), init) {}
 
     friend bool
-    operator<=>(const Array &, const Array &) = default;
+    operator<=>(const MD_Array &, const MD_Array &) = default;
 
     const_reference
     operator()(integral auto i, integral auto j, integral auto... ks) const {
@@ -123,7 +123,7 @@ namespace lbm::core {
     }
 
     friend void
-    to_json(json &j, const Array &array) {
+    to_json(json &j, const MD_Array &array) {
       j = json::object();
       j["Array"] = json::object();
       j["Array"]["order"] = array.order_;
@@ -131,7 +131,7 @@ namespace lbm::core {
     }
 
     friend void
-    from_json(const json &j, Array &array) {
+    from_json(const json &j, MD_Array &array) {
       array.order_ = j["Array"]["order"];
       array.values_.resize(j["Array"]["values"].size());
       copy(std::begin(j["Array"]["values"]),
@@ -140,12 +140,12 @@ namespace lbm::core {
     }
 
     friend ostream &
-    operator<<(ostream &os, const Array &array) {
+    operator<<(ostream &os, const MD_Array &array) {
       return os << json(array);
     }
 
     friend istream &
-    operator>>(istream &is, Array &array) {
+    operator>>(istream &is, MD_Array &array) {
       array = json::parse(is);
       return is;
     }

--- a/cxx/lbm/core/Array2.hpp
+++ b/cxx/lbm/core/Array2.hpp
@@ -1,0 +1,373 @@
+#pragma once
+
+//
+// ... LBM Bench header files
+//
+#include <lbm/core/Array.hpp>
+#include <lbm/core/Boundary_ID.hpp>
+#include <lbm/core/import.hpp>
+
+namespace lbm::core {
+
+  struct Interior {
+  } constexpr interior{};
+
+  struct Left {
+  } constexpr left{};
+
+  struct Right {
+  } constexpr right{};
+
+  struct Bottom {
+  } constexpr bottom{};
+
+  struct Top {
+  } constexpr top{};
+
+  template <class T>
+  concept Boundary_Tag =
+      same_as<Left, T> || same_as<Right, T> || same_as<Bottom, T> || same_as<Top, T>;
+
+  /**
+   * @brief A type describing degree 2 arrays
+   *
+   * @details This class derives from the more generic `MD_Array` class
+   * with enhancements for iterating over specified boundaries and the
+   * interior of the array.
+   */
+  template <class T>
+  class Array2 : public MD_Array<T, 2> {
+  public:
+    using Value_Type = T;
+    using Reference = T &;
+    using Const_Reference = const T &;
+
+    using Base = MD_Array<T, 2>;
+    using Base::Base;
+
+  private:
+    /**
+     * @brief A type describing an element reference enhanced by
+     * access to the position of the element.
+     *
+     * @tparam Modifier  - A template template parameter used to
+     * specify the reference as `const` or not `const`.
+     */
+    template <template <class> class Modifier>
+    class Generic_Element_Reference {
+      using Array_Reference = typename Modifier<Array2>::type;
+      using Element_Reference = typename Modifier<T>::type;
+
+    public:
+      Generic_Element_Reference() = delete;
+      Generic_Element_Reference(const Generic_Element_Reference &) = default;
+      Generic_Element_Reference(Array_Reference array_ref, size_type i, size_type j)
+          : array_ref_{array_ref}
+          , i_{i}
+          , j_{j} {}
+
+      Generic_Element_Reference &
+      operator=(Const_Reference input) {
+        array_ref_(i_, j_) = input;
+        return *this;
+      }
+
+      array<size_type, 2>
+      indices() const {
+        return {i_, j_};
+      }
+
+      operator Element_Reference() { return array_ref_(i_, j_); }
+
+    private:
+      Array_Reference array_ref_;
+      size_type i_;
+      size_type j_;
+    };
+
+    template <typename U>
+    struct Add_Const_Reference : add_lvalue_reference<add_const_t<U>> {};
+
+  public:
+    using Element_Reference = Generic_Element_Reference<add_lvalue_reference>;
+    using Cegonst_Element_Reference = Generic_Element_Reference<Add_Const_Reference>;
+
+  private:
+    /**
+     * @brief A type describing a iterator over a boundary
+     *
+     * @tparam boundary - A template value parameter specifing the boundary to iterate over.
+     * @tparam Modifier - A template template parameter specifying the constness of the reference.
+     */
+    template <Boundary_ID boundary, template <class> class Modifier>
+    class Generic_Boundary_Iterator {
+    public:
+      using Array_Reference = typename Modifier<Array2>::type;
+      using Value_Reference = typename Modifier<T>::type;
+      using Element_Reference = Generic_Element_Reference<Modifier>;
+
+      Generic_Boundary_Iterator(const Generic_Boundary_Iterator &) = default;
+      Generic_Boundary_Iterator(Array_Reference ref, size_type index)
+          : ref_{ref}
+          , index_{index} {}
+
+      Value_Reference
+      operator()(size_type ioffset, size_type joffset) {
+        if constexpr (boundary == Boundary_ID::Left) {
+          return ref_(ioffset, index_ + joffset);
+        } else if constexpr (boundary == Boundary_ID::Right) {
+          const auto nxm1 = ref_.size(0) - 1;
+          return ref_(nxm1 + ioffset, index_ + joffset);
+        } else if constexpr (boundary == Boundary_ID::Bottom) {
+          return ref_(index_ + ioffset, joffset);
+        } else if constexpr (boundary == Boundary_ID::Top) {
+          const auto nym1 = ref_.size(1) - 1;
+          return ref_(index_ + ioffset, nym1 + joffset);
+        }
+      }
+
+      Generic_Boundary_Iterator &
+      operator+=(size_type offset) {
+        index_ += offset;
+        return *this;
+      }
+
+      Generic_Boundary_Iterator &
+      operator-=(size_type offset) {
+        return *this += -offset;
+      }
+
+      Generic_Boundary_Iterator &
+      operator++() {
+        return *this += 1;
+      }
+
+      Generic_Boundary_Iterator
+      operator++(int) {
+        Generic_Boundary_Iterator result{*this};
+        *this += 1;
+        return result;
+      }
+
+      Generic_Boundary_Iterator &
+      operator--() {
+        return *this -= 1;
+      }
+
+      Generic_Boundary_Iterator
+      operator--(int) {
+        Boundary_Iterator result{*this};
+        *this -= 1;
+        return result;
+      }
+
+      Element_Reference
+      operator*() {
+        if constexpr (boundary == Boundary_ID::Left) {
+          return {ref_, 0, index_};
+        } else if constexpr (boundary == Boundary_ID::Right) {
+          const auto nxm1 = ref_.size(0) - 1;
+          return {ref_, nxm1, index_};
+        } else if constexpr (boundary == Boundary_ID::Bottom) {
+          return {ref_, index_, 0};
+        } else if constexpr (boundary == Boundary_ID::Top) {
+          const auto nym1 = ref_.size(1) - 1;
+          return {ref_, index_, nym1};
+        }
+      }
+
+      friend bool
+      operator==(const Generic_Boundary_Iterator &iter1, const Generic_Boundary_Iterator &iter2) {
+        return &iter1.ref_ == &iter2.ref_ && iter1.index_ == iter2.index_;
+      }
+
+      friend bool
+      operator!=(const Generic_Boundary_Iterator &iter1, const Generic_Boundary_Iterator &iter2) {
+        return !(iter1 == iter2);
+      }
+
+      size_type
+      distance(const Generic_Boundary_Iterator &iter) const {
+        return iter.index_ - index_;
+      }
+
+    private:
+      Array_Reference &ref_;
+      size_type index_;
+    };
+
+  public:
+    template <Boundary_ID boundary>
+    using Boundary_Iterator = Generic_Boundary_Iterator<boundary, add_lvalue_reference>;
+
+    template <Boundary_ID boundary>
+    using Const_Boundary_Iterator = Generic_Boundary_Iterator<boundary, Add_Const_Reference>;
+
+  private:
+    template <template <class> class Modifier>
+    class Generic_Interior_Iterator {
+    public:
+      using Array_Reference = typename Modifier<Array2>::type;
+      using Value_Reference = typename Modifier<T>::type;
+      using Element_Reference = Generic_Element_Reference<Modifier>;
+
+      Generic_Interior_Iterator() = delete;
+      Generic_Interior_Iterator(const Generic_Interior_Iterator &) = default;
+      Generic_Interior_Iterator(Array_Reference array_ref, size_type i, size_type j)
+          : array_ref_{array_ref}
+          , i_(i)
+          , j_(j)
+          , nym1_{array_ref_.size(1) - 1} {}
+
+      Generic_Interior_Iterator &
+      operator++() {
+        ++j_;
+        if (j_ == nym1_) {
+          ++i_;
+          j_ = 1;
+        }
+        return *this;
+      }
+
+      Generic_Interior_Iterator
+      operator++(int) {
+        Generic_Interior_Iterator result = *this;
+        ++(*this);
+        return result;
+      }
+
+      friend bool
+      operator==(const Generic_Interior_Iterator &iter1, const Generic_Interior_Iterator &iter2) {
+        return &iter1.array_ref_ == &iter2.array_ref_ && iter1.i_ == iter2.i_ &&
+               iter1.j_ == iter2.j_;
+      }
+
+      friend bool
+      operator!=(const Generic_Interior_Iterator &iter1, const Generic_Interior_Iterator &iter2) {
+        return !(iter1 == iter2);
+      }
+
+      Value_Reference
+      operator()(size_type ioffset, size_type joffset) {
+        return array_ref_(i_ + ioffset, j_ + joffset);
+      }
+
+      Element_Reference
+      operator*() {
+        return {array_ref_, i_, j_};
+      }
+
+    private:
+      Array_Reference array_ref_;
+      size_type i_;
+      size_type j_;
+      size_type nym1_;
+    };
+
+  public:
+    using Interior_Iterator = Generic_Interior_Iterator<add_lvalue_reference>;
+    using Const_Interior_Iterator = Generic_Interior_Iterator<Add_Const_Reference>;
+
+    using Base::begin;
+    using Base::cbegin;
+    using Base::cend;
+    using Base::end;
+
+    template <Boundary_ID boundary>
+    Boundary_Iterator<boundary>
+    begin() {
+      return {*this, 1};
+    }
+
+    template <Boundary_ID boundary>
+    Boundary_Iterator<boundary>
+    end() {
+      if constexpr (boundary == Boundary_ID::Left || boundary == Boundary_ID::Right) {
+        return {*this, this->size(1) - 1};
+      } else if constexpr (boundary == Boundary_ID::Bottom || boundary == Boundary_ID::Top) {
+        return {*this, this->size(0) - 1};
+      } else {
+        unreachable_code(source_location::current());
+      }
+    }
+
+    template <Boundary_ID boundary>
+    Const_Boundary_Iterator<boundary>
+    begin() const {
+      return {*this, 1};
+    }
+
+    template <Boundary_ID boundary>
+    Const_Boundary_Iterator<boundary>
+    end() const {
+      if constexpr (boundary == Boundary_ID::Left || boundary == Boundary_ID::Right) {
+        return {*this, this->size(1) - 1};
+      } else if constexpr (boundary == Boundary_ID::Bottom || boundary == Boundary_ID::Top) {
+        return {*this, this->size(0) - 1};
+      } else {
+        unreachable_code(source_location::current());
+      }
+    }
+
+    template <Boundary_ID boundary>
+    Const_Boundary_Iterator<boundary>
+    cbegin() const {
+      return begin<boundary>();
+    }
+
+    template <Boundary_ID boundary>
+    Const_Boundary_Iterator<boundary>
+    cend() const {
+      return end<boundary>();
+    }
+
+    Interior_Iterator
+    begin(Interior) {
+      return {*this, 1, 1};
+    }
+
+    Interior_Iterator
+    end(Interior) {
+      return {*this, Base::size(0) - 1, 1};
+    }
+
+    Const_Interior_Iterator
+    begin(Interior) const {
+      return {*this, 1, 1};
+    }
+
+    Const_Interior_Iterator
+    end(Interior) const {
+      return {*this, Base::size(0) - 1, 1};
+    }
+
+    Const_Interior_Iterator
+    cbegin(Interior) const {
+      return begin(interior);
+    }
+
+    Const_Interior_Iterator
+    cend(Interior) const {
+      return end(interior);
+    }
+  };
+
+} // namespace lbm::core
+
+namespace std {
+
+  template <class T, lbm::core::Boundary_ID boundary>
+  ptrdiff_t
+  distance(const typename lbm::core::Array2<T>::template Boundary_Iterator<boundary> &iter1,
+           const typename lbm::core::Array2<T>::template Boundary_Iterator<boundary> &iter2) {
+    return iter1.distance(iter2);
+  }
+
+  template <class T, lbm::core::Boundary_ID boundary>
+  ptrdiff_t
+  distance(const typename lbm::core::Array2<T>::template Const_Boundary_Iterator<boundary> &iter1,
+           const typename lbm::core::Array2<T>::template Const_Boundary_Iterator<boundary> &iter2) {
+    return iter1.distance(iter2);
+  }
+
+} // end of namespace std

--- a/cxx/lbm/core/Boundary_Condition.cpp
+++ b/cxx/lbm/core/Boundary_Condition.cpp
@@ -99,6 +99,9 @@ namespace lbm::core {
 
   void
   Wall::set_json(const json &j) {
+    assert(j.contains("/wall"_json_pointer));
+    assert(j.contains("/wall/boundary"_json_pointer));
+
     boundary_ = j["wall"]["boundary"];
   }
 
@@ -126,13 +129,17 @@ namespace lbm::core {
   json
   Symmetry::get_json() const {
     json j = json::object();
-    j["symmetry"] = boundary_;
+    j["symmetry"] = json::object();
+    j["symmetry"]["boundary"] = boundary_;
     return j;
   }
 
   void
   Symmetry::set_json(const json &j) {
-    boundary_ = j["symmetry"];
+    assert(j.contains("/symmetry"_json_pointer));
+    assert(j.contains("/symmetry/boundary"_json_pointer));
+
+    boundary_ = j["symmetry"]["boundary"];
   }
 
   //
@@ -173,13 +180,21 @@ namespace lbm::core {
   json
   Inlet::get_json() const {
     json j = json::object();
+    j["inlet"] = json::object();
     j["inlet"]["boundary"] = boundary_;
-    j["inlet"]["inletSpeed"] = speed_;
+    j["inlet"]["density"] = density_;
+    j["inlet"]["speed"] = speed_;
+
     return j;
   }
 
   void
   Inlet::set_json(const json &j) {
+    assert(j.contains("/inlet"_json_pointer));
+    assert(j.contains("/inlet/boundary"_json_pointer));
+    assert(j.contains("/inlet/density"_json_pointer));
+    assert(j.contains("/inlet/speed"_json_pointer));
+
     boundary_ = j["inlet"]["boundary"];
     density_ = j["inlet"]["density"];
     speed_ = j["inlet"]["speed"];
@@ -232,8 +247,13 @@ namespace lbm::core {
 
   void
   Outlet::set_json(const json &j) {
+    assert(j.contains("/outlet"_json_pointer));
+    assert(j.contains("/outlet/boundary"_json_pointer));
+    assert(j.contains("/outlet/density"_json_pointer));
+    assert(j.contains("/outlet/speed"_json_pointer));
+
     boundary_ = j["outlet"]["boundary"];
-    density_ = j["outlet"]["dentity"];
+    density_ = j["outlet"]["density"];
     speed_ = j["outlet"]["speed"];
   }
 
@@ -271,6 +291,9 @@ namespace lbm::core {
 
   void
   Pressure_Drop::set_json(const json &j) {
+    assert(j.contains("/pressureDrop/boundary"_json_pointer));
+    assert(j.contains("/pressureDrop/value"_json_pointer));
+
     boundary_ = j["pressureDrop"]["boundary"];
     value_ = j["pressureDrop"]["value"];
   }

--- a/cxx/lbm/core/Boundary_Condition.cpp
+++ b/cxx/lbm/core/Boundary_Condition.cpp
@@ -139,18 +139,30 @@ namespace lbm::core {
   // ... Inlet
   //
 
-  Inlet::Inlet(Boundary_ID boundary, double inlet_speed)
+  Inlet::Inlet(Boundary_ID boundary, double density, double speed)
       : boundary_{boundary}
-      , inlet_speed_{inlet_speed} {}
+      , density_{density}
+      , speed_{speed} {}
 
   bool
   operator==(const Inlet &inlet1, const Inlet &inlet2) {
-    return inlet1.boundary_ == inlet2.boundary_ && inlet1.inlet_speed_ == inlet2.inlet_speed_;
+    return inlet1.boundary_ == inlet2.boundary_ && inlet1.density_ == inlet2.density_ &&
+           inlet1.speed_ == inlet2.speed_;
   }
 
   bool
   operator!=(const Inlet &inlet1, const Inlet &inlet2) {
     return !(inlet1 == inlet2);
+  }
+
+  double
+  Inlet::density() const {
+    return density_;
+  }
+
+  double
+  Inlet::speed() const {
+    return speed_;
   }
 
   Boundary_ID
@@ -162,32 +174,45 @@ namespace lbm::core {
   Inlet::get_json() const {
     json j = json::object();
     j["inlet"]["boundary"] = boundary_;
-    j["inlet"]["inletSpeed"] = inlet_speed_;
+    j["inlet"]["inletSpeed"] = speed_;
     return j;
   }
 
   void
   Inlet::set_json(const json &j) {
     boundary_ = j["inlet"]["boundary"];
-    inlet_speed_ = j["inlet"]["inletSpeed"];
+    density_ = j["inlet"]["density"];
+    speed_ = j["inlet"]["speed"];
   }
 
   //
   // ... Outlet
   //
 
-  Outlet::Outlet(Boundary_ID boundary, double outlet_speed)
+  Outlet::Outlet(Boundary_ID boundary, double density, double speed)
       : boundary_{boundary}
-      , outlet_speed_{outlet_speed} {}
+      , density_{density}
+      , speed_{speed} {}
 
   bool
   operator==(const Outlet &outlet1, const Outlet &outlet2) {
-    return outlet1.boundary_ == outlet2.boundary_ && outlet1.outlet_speed_ == outlet2.outlet_speed_;
+    return outlet1.boundary_ == outlet2.boundary_ && outlet1.density_ == outlet2.density_ &&
+           outlet1.speed_ == outlet2.speed_;
   }
 
   bool
   operator!=(const Outlet &outlet1, const Outlet &outlet2) {
     return !(outlet1 == outlet2);
+  }
+
+  double
+  Outlet::density() const {
+    return density_;
+  }
+
+  double
+  Outlet::speed() const {
+    return speed_;
   }
 
   Boundary_ID
@@ -200,14 +225,16 @@ namespace lbm::core {
     json j = json::object();
     j["outlet"] = json::object();
     j["outlet"]["boundary"] = boundary_;
-    j["outlet"]["outletSpeed"] = outlet_speed_;
+    j["outlet"]["density"] = density_;
+    j["outlet"]["speed"] = speed_;
     return j;
   }
 
   void
   Outlet::set_json(const json &j) {
     boundary_ = j["outlet"]["boundary"];
-    outlet_speed_ = j["outlet"]["outletSpeed"];
+    density_ = j["outlet"]["dentity"];
+    speed_ = j["outlet"]["speed"];
   }
 
   //

--- a/cxx/lbm/core/Boundary_Condition.hpp
+++ b/cxx/lbm/core/Boundary_Condition.hpp
@@ -56,7 +56,7 @@ namespace lbm::core {
   class Inlet final : public JSON_Convertible {
   public:
     Inlet() = default;
-    Inlet(Boundary_ID boundary, double inlet_speed);
+    Inlet(Boundary_ID boundary, double density, double speed);
 
     friend bool
     operator==(const Inlet &inlet1, const Inlet &inlet2);
@@ -67,6 +67,12 @@ namespace lbm::core {
     Boundary_ID
     boundary() const;
 
+    double
+    density() const;
+
+    double
+    speed() const;
+
   private:
     json
     get_json() const override;
@@ -75,13 +81,14 @@ namespace lbm::core {
     set_json(const json &j) override;
 
     Boundary_ID boundary_{};
-    double inlet_speed_{};
+    double density_{};
+    double speed_{};
   };
 
   class Outlet final : public JSON_Convertible {
   public:
     Outlet() = default;
-    Outlet(Boundary_ID boundary, double outlet_speed);
+    Outlet(Boundary_ID boundary, double density, double speed);
 
     friend bool
     operator==(const Outlet &outlet1, const Outlet &outlet2);
@@ -92,6 +99,12 @@ namespace lbm::core {
     Boundary_ID
     boundary() const;
 
+    double
+    density() const;
+
+    double
+    speed() const;
+
   private:
     json
     get_json() const override;
@@ -100,7 +113,8 @@ namespace lbm::core {
     set_json(const json &j) override;
 
     Boundary_ID boundary_{};
-    double outlet_speed_{};
+    double density_{};
+    double speed_{};
   };
 
   class Pressure_Drop final : public JSON_Convertible {

--- a/cxx/lbm/core/Boundary_ID.cpp
+++ b/cxx/lbm/core/Boundary_ID.cpp
@@ -7,22 +7,22 @@ namespace lbm::core {
     using enum Boundary_ID;
     switch (id) {
     case Left:
-      j = "Left";
+      j = "left";
       break;
     case Right:
-      j = "Right";
+      j = "right";
       break;
     case Bottom:
-      j = "Bottom";
+      j = "bottom";
       break;
     case Top:
-      j = "Top";
+      j = "top";
       break;
     case Front:
-      j = "Front";
+      j = "front";
       break;
     case Back:
-      j = "Back";
+      j = "back";
       break;
     }
   }
@@ -30,17 +30,17 @@ namespace lbm::core {
   void
   from_json(const json &j, Boundary_ID &id) {
     using enum Boundary_ID;
-    if (j == "Left") {
+    if (j == "left") {
       id = Left;
-    } else if (j == "Right") {
+    } else if (j == "right") {
       id = Right;
-    } else if (j == "Bottom") {
+    } else if (j == "bottom") {
       id = Bottom;
-    } else if (j == "Top") {
+    } else if (j == "top") {
       id = Top;
-    } else if (j == "Front") {
+    } else if (j == "front") {
       id = Front;
-    } else if (j == "Back") {
+    } else if (j == "back") {
       id = Back;
     }
   }

--- a/cxx/lbm/core/Dynamic_Array.hpp
+++ b/cxx/lbm/core/Dynamic_Array.hpp
@@ -9,7 +9,7 @@
 namespace lbm::core {
 
   template <class T>
-  class Dynamic_Array
+  class Dynamic_MD_Array
       : public vector<T>
       , public JSON_Convertible {
   public:

--- a/cxx/lbm/core/Fixed_Array.hpp
+++ b/cxx/lbm/core/Fixed_Array.hpp
@@ -16,10 +16,10 @@
 namespace lbm::core {
 
   template <class T, class Order>
-  class Fixed_Array;
+  class Fixed_MD_Array;
 
   template <class T, size_type... N>
-  class Fixed_Array<T, Fixed_Lexical<N...>> : public JSON_Convertible {
+  class Fixed_MD_Array<T, Fixed_Lexical<N...>> : public JSON_Convertible {
   public:
     using Value_Type = T;
     using Reference = T &;
@@ -31,15 +31,15 @@ namespace lbm::core {
     static constexpr size_type storage_size = (N * ...);
     using Storage = std::array<T, storage_size>;
 
-    constexpr Fixed_Array() = default;
-    constexpr explicit Fixed_Array(T init) { std::fill(cbegin(storage_), cend(storage_), init); }
+    constexpr Fixed_MD_Array() = default;
+    constexpr explicit Fixed_MD_Array(T init) { std::fill(cbegin(storage_), cend(storage_), init); }
 
-    constexpr Fixed_Array(T x1, T x2, same_as<T> auto... xs)
+    constexpr Fixed_MD_Array(T x1, T x2, same_as<T> auto... xs)
         : storage_{{x1, x2, xs...}} {
       static_assert(2 + sizeof...(xs) == size());
     }
 
-    Fixed_Array &
+    Fixed_MD_Array &
     fill(Value_Type x) {
       using std::fill;
       fill(std::begin(storage_), std::end(storage_), x);
@@ -70,32 +70,32 @@ namespace lbm::core {
     operator()(size_type i, size_type j, integral auto... ks) const {
       static_assert(2 + sizeof...(ks) == degree);
       static_assert(Order::degree == degree);
-      assert(Order::storage_index(Fixed_Array_Index<degree>(i, j, size_type(ks)...)) <
+      assert(Order::storage_index(Fixed_MD_Array_Index<degree>(i, j, size_type(ks)...)) <
              storage_size);
-      return storage_[Order::storage_index(Fixed_Array_Index<degree>(i, j, size_type(ks)...))];
+      return storage_[Order::storage_index(Fixed_MD_Array_Index<degree>(i, j, size_type(ks)...))];
     }
 
     Reference
     operator()(size_type i, size_type j, integral auto... ks) {
       static_assert(2 + sizeof...(ks) == degree);
       static_assert(Order::degree == degree);
-      return storage_[Order::storage_index(Fixed_Array_Index(i, j, size_type(ks)...))];
+      return storage_[Order::storage_index(Fixed_MD_Array_Index(i, j, size_type(ks)...))];
     }
 
     constexpr Const_Reference
     at(size_type i, size_type j, integral auto... ks) const {
       static_assert(2 + sizeof...(ks) == degree);
       static_assert(Order::degree == degree);
-      assert(Order::storage_index(Fixed_Array_Index<degree>(i, j, size_type(ks)...)) <
+      assert(Order::storage_index(Fixed_MD_Array_Index<degree>(i, j, size_type(ks)...)) <
              storage_size);
-      return storage_[Order::storage_index(Fixed_Array_Index<degree>(i, j, size_type(ks)...))];
+      return storage_[Order::storage_index(Fixed_MD_Array_Index<degree>(i, j, size_type(ks)...))];
     }
 
     Reference
     at(size_type i, size_type j, integral auto... ks) {
       static_assert(2 + sizeof...(ks) == degree);
       static_assert(Order::degree == degree);
-      return storage_[Order::storage_index(Fixed_Array_Index(i, j, size_type(ks)...))];
+      return storage_[Order::storage_index(Fixed_MD_Array_Index(i, j, size_type(ks)...))];
     }
 
     auto
@@ -133,13 +133,13 @@ namespace lbm::core {
     }
 
     friend bool
-    operator==(const Fixed_Array &x, const Fixed_Array &y) {
+    operator==(const Fixed_MD_Array &x, const Fixed_MD_Array &y) {
       return transform_reduce(
           std::begin(x), std::end(x), std::begin(y), true, logical_and{}, equal_to{});
     }
 
     friend bool
-    operator!=(const Fixed_Array &x, const Fixed_Array &y) {
+    operator!=(const Fixed_MD_Array &x, const Fixed_MD_Array &y) {
       return !(x == y);
     }
 

--- a/cxx/lbm/core/Fixed_Array.hpp
+++ b/cxx/lbm/core/Fixed_Array.hpp
@@ -39,6 +39,22 @@ namespace lbm::core {
       static_assert(2 + sizeof...(xs) == size());
     }
 
+    friend constexpr Fixed_MD_Array
+    operator+(const Fixed_MD_Array &xs, const Fixed_MD_Array &ys) {
+      return [&]<std::size_t... i>(index_sequence<i...>) {
+        return Fixed_MD_Array{xs[i] + ys[i]...};
+      }
+      (make_index_sequence<storage_size>());
+    }
+
+    friend constexpr Fixed_MD_Array
+    operator-(const Fixed_MD_Array &xs, const Fixed_MD_Array &ys) {
+      return [&]<std::size_t... i>(index_sequence<i...>) {
+        return Fixed_MD_Array{xs[i] - ys[i]...};
+      }
+      (make_index_sequence<storage_size>());
+    }
+
     Fixed_MD_Array &
     fill(Value_Type x) {
       using std::fill;

--- a/cxx/lbm/core/Fixed_Array_Index.hpp
+++ b/cxx/lbm/core/Fixed_Array_Index.hpp
@@ -14,49 +14,49 @@
 namespace lbm::core {
 
   template <size_type N>
-  class Fixed_Array_Index : public array<size_type, N> {
+  class Fixed_MD_Array_Index : public array<size_type, N> {
   public:
     using Base = array<size_type, N>;
     using Base::Base;
-    constexpr Fixed_Array_Index(integral auto n1,
-                                integral auto n2,
-                                convertible_to<size_type> auto... ns)
+    constexpr Fixed_MD_Array_Index(integral auto n1,
+                                   integral auto n2,
+                                   convertible_to<size_type> auto... ns)
         : Base{{size_type(n1), size_type(n2), size_type(ns)...}} {}
 
     friend constexpr bool
-    operator<=>(const Fixed_Array_Index &idx1, const Fixed_Array_Index &idx2) = default;
+    operator<=>(const Fixed_MD_Array_Index &idx1, const Fixed_MD_Array_Index &idx2) = default;
 
     friend void
-    from_json(const json &j, Fixed_Array_Index &idx) {
+    from_json(const json &j, Fixed_MD_Array_Index &idx) {
       static_cast<Base &>(idx) = j["FixedArrayIndex"];
     }
 
     friend void
-    to_json(json &j, const Fixed_Array_Index &idx) {
+    to_json(json &j, const Fixed_MD_Array_Index &idx) {
       j = json::object();
       j["FixedArrayIndex"] = static_cast<const Base &>(idx);
     }
 
     friend ostream &
-    operator<<(ostream &os, const Fixed_Array_Index &idx) {
+    operator<<(ostream &os, const Fixed_MD_Array_Index &idx) {
       return os << json(idx);
     }
 
     friend istream &
-    operator>>(istream &is, Fixed_Array_Index &idx) {
+    operator>>(istream &is, Fixed_MD_Array_Index &idx) {
       idx = json::parse(is);
       return is;
     }
   };
 
-  Fixed_Array_Index(size_type, size_type, convertible_to<size_type> auto... ns)
-      -> Fixed_Array_Index<sizeof...(ns) + 2>;
+  Fixed_MD_Array_Index(size_type, size_type, convertible_to<size_type> auto... ns)
+      -> Fixed_MD_Array_Index<sizeof...(ns) + 2>;
 
 } // end of namespace lbm::core
 
 namespace std {
 
   template <lbm::core::size_type N>
-  struct tuple_size<lbm::core::Fixed_Array_Index<N>> : integral_constant<size_t, N> {};
+  struct tuple_size<lbm::core::Fixed_MD_Array_Index<N>> : integral_constant<size_t, N> {};
 
 } // end of namespace std

--- a/cxx/lbm/core/Fixed_Lexical.hpp
+++ b/cxx/lbm/core/Fixed_Lexical.hpp
@@ -18,7 +18,7 @@ namespace lbm::core {
 
     static constexpr data_type extents{{Ns...}};
 
-    using Index = Fixed_Array_Index<degree>;
+    using Index = Fixed_MD_Array_Index<degree>;
 
     static constexpr data_type strides = [] {
       const auto recur = [](auto recur, size_type stride, same_as<size_type> auto... strides) {

--- a/cxx/lbm/core/Input.cpp
+++ b/cxx/lbm/core/Input.cpp
@@ -76,6 +76,18 @@ namespace lbm::core {
     return lattice_.lattice_spacing();
   }
 
+  Boundary_Condition
+  Input::boundary(Boundary_ID id) const {
+    Boundary_Condition bc = Wall{id};
+    for (auto input_bc : boundary_conditions_) {
+      if (input_bc.boundary() == id) {
+        bc = input_bc;
+        break;
+      }
+    }
+    return bc;
+  }
+
   bool
   operator==(const Input &inp0, const Input &inp1) {
     // clang-format off

--- a/cxx/lbm/core/Lexical.hpp
+++ b/cxx/lbm/core/Lexical.hpp
@@ -61,7 +61,7 @@ namespace lbm::core {
     friend void
     to_json(json &j, const Lexical &order) {
       j = json::object();
-      j["Lexical"] = order.shape_;
+      j["Lexical"] = json(order.shape_);
     }
 
     friend void

--- a/cxx/lbm/core/forall.hpp
+++ b/cxx/lbm/core/forall.hpp
@@ -28,8 +28,8 @@ namespace lbm::core {
    * not the dereferenced value, and accepts to ranges.
    */
   template <class Input_Iter1, class Input_Iter2, class Binary_Function>
-  Unary_Function
-  forall(Input_Iter first1, Input_Iter last1, Input_Iter first2, Binary_Function func) {
+  Binary_Function
+  forall(Input_Iter1 first1, Input_Iter1 last1, Input_Iter2 first2, Binary_Function func) {
     while (first1 != last1) {
       func(first1++, first2++);
     }

--- a/cxx/lbm/core/forall.hpp
+++ b/cxx/lbm/core/forall.hpp
@@ -18,4 +18,22 @@ namespace lbm::core {
     }
     return func;
   }
+
+  /**
+   * @brief Function passing every iterator from two half-open ranges to
+   * an input binary function, which is return.
+   *
+   * @details This function is similar to the `std::for_each`, whith
+   * notable exception that it passes the iterator to the function,
+   * not the dereferenced value, and accepts to ranges.
+   */
+  template <class Input_Iter1, class Input_Iter2, class Binary_Function>
+  Unary_Function
+  forall(Input_Iter first1, Input_Iter last1, Input_Iter first2, Binary_Function func) {
+    while (first1 != last1) {
+      func(first1++, first2++);
+    }
+    return func;
+  }
+
 } // end of namespace lbm::core

--- a/cxx/lbm/core/forall.hpp
+++ b/cxx/lbm/core/forall.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace lbm::core {
+
+  /**
+   * @brief Function passing every iterator in a half-open range to
+   * an input function.
+   *
+   * @details This function is similar to the `std::for_each`, whith
+   * notable exception that it passes the iterator to the function,
+   * not the dereferenced value.
+   */
+  template <class Input_Iter, class Unary_Function>
+  Unary_Function
+  forall(Input_Iter first, Input_Iter last, Unary_Function func) {
+    while (first != last) {
+      func(first++);
+    }
+    return func;
+  }
+} // end of namespace lbm::core

--- a/cxx/lbm/core/import.hpp
+++ b/cxx/lbm/core/import.hpp
@@ -21,6 +21,7 @@
 #include <concepts>
 #include <functional>
 #include <iostream>
+#include <iterator>
 #include <numeric>
 #include <source_location>
 #include <sstream>
@@ -55,6 +56,7 @@ namespace lbm::core {
   using std::transform_reduce;
 
   // from functional
+  using std::copy;
   using std::equal_to;
   using std::function;
   using std::logical_and;
@@ -86,6 +88,9 @@ namespace lbm::core {
 
   // from functional
   using std::multiplies;
+
+  // from iterator
+  using std::back_inserter;
 
   // from numeric
   using std::accumulate;

--- a/cxx/lbm/core/import.hpp
+++ b/cxx/lbm/core/import.hpp
@@ -5,6 +5,7 @@
 //
 #include <lbm/exceptions/Bad_Float_Type.hpp>
 #include <lbm/exceptions/Bad_Kernel_Name.hpp>
+#include <lbm/exceptions/Unreachable.hpp>
 
 //
 // ... Third-party header files
@@ -21,6 +22,7 @@
 #include <functional>
 #include <iostream>
 #include <numeric>
+#include <source_location>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -38,6 +40,7 @@ namespace lbm::core {
 
   using lbm::exceptions::Bad_Float_Type;
   using lbm::exceptions::Bad_Kernel_Name;
+  using lbm::exceptions::unreachable_code;
 
   // from utility
   using std::index_sequence;
@@ -101,9 +104,14 @@ namespace lbm::core {
   using std::visit;
 
   // from type_traits
+  using std::add_const_t;
+  using std::add_lvalue_reference;
   using std::common_type_t;
   using std::is_default_constructible_v;
   using std::remove_cvref_t;
+
+  // from source_location
+  using std::source_location;
 
   // from memory
   using std::make_shared;

--- a/cxx/lbm/core/subdomain_tags.cpp
+++ b/cxx/lbm/core/subdomain_tags.cpp
@@ -1,0 +1,312 @@
+//
+// ... LBM Bench header files
+//
+#include <lbm/core/subdomain_tags.hpp>
+
+namespace lbm::core {
+
+  //
+  // ... Interior
+  //
+  void
+  to_json(json &j, const Interior &) {
+    j = "interior";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Interior &) {
+    assert(j == "interior");
+  }
+
+  //
+  // ... Faces 2D and 3D
+  //
+
+  void
+  to_json(json &j, const Left &) {
+    j = "left";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Left &) {
+    assert(j == "left");
+  }
+
+  void
+  to_json(json &j, const Right &) {
+    j = "right";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Right &) {
+    assert(j == "right");
+  }
+
+  void
+  to_json(json &j, const Bottom &) {
+    j = "bottom";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Bottom &) {
+    assert(j == "bottom");
+  }
+  void
+  to_json(json &j, const Top &) {
+    j = "top";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Top &) {
+    assert(j == "top");
+  }
+  void
+  to_json(json &j, const Back &) {
+    j = "back";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Back &) {
+    assert(j == "back");
+  }
+  void
+  to_json(json &j, const Front &) {
+    j = "front";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Front &) {
+    assert(j == "front");
+  }
+
+  //
+  // ... Corners 2D
+  //
+  void
+  to_json(json &j, const Left_Bottom_Corner &) {
+    j = "left_bottom_corner";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Left_Bottom_Corner &) {
+    assert(j == "left_bottom_corner");
+  }
+  void
+  to_json(json &j, const Left_Top_Corner &) {
+    j = "left_top_corner";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Left_Top_Corner &) {
+    assert(j == "left_top_corner");
+  }
+  void
+  to_json(json &j, const Right_Bottom_Corner &) {
+    j = "right_bottom_corner";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Right_Bottom_Corner &) {
+    assert(j == "right_bottom_corner");
+  }
+  void
+  to_json(json &j, const Right_Top_Corner &) {
+    j = "right_top_corner";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Right_Top_Corner &) {
+    assert(j == "right_top_corner");
+  }
+
+  //
+  // ... Edges 3D
+  //
+
+  void
+  to_json(json &j, const Left_Bottom_Edge &) {
+    j = "left_bottom_edge";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Left_Bottom_Edge &) {
+    assert(j == "left_bottom_edge");
+  }
+  void
+  to_json(json &j, const Left_Top_Edge &) {
+    j = "left_top_edge";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Left_Top_Edge &) {
+    assert(j == "left_top_edge");
+  }
+  void
+  to_json(json &j, const Right_Bottom_Edge &) {
+    j = "right_bottom_edge";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Right_Bottom_Edge &) {
+    assert(j == "right_bottom_edge");
+  }
+  void
+  to_json(json &j, const Right_Top_Edge &) {
+    j = "right_top_edge";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Right_Top_Edge &) {
+    assert(j == "right_top_edge");
+  }
+  void
+  to_json(json &j, const Left_Back_Edge &) {
+    j = "left_back_edge";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Left_Back_Edge &) {
+    assert(j == "left_back_edge");
+  }
+  void
+  to_json(json &j, const Left_Front_Edge &) {
+    j = "left_front_edge";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Left_Front_Edge &) {
+    assert(j == "left_front_edge");
+  }
+  void
+  to_json(json &j, const Right_Back_Edge &) {
+    j = "right_back_edge";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Right_Back_Edge &) {
+    assert(j == "right_back_edge");
+  }
+  void
+  to_json(json &j, const Right_Front_Edge &) {
+    j = "right_front_edge";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Right_Front_Edge &) {
+    assert(j == "right_front_edge");
+  }
+  void
+  to_json(json &j, const Bottom_Back_Edge &) {
+    j = "bottom_back_edge";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Bottom_Back_Edge &) {
+    assert(j == "bottom_back_edge");
+  }
+  void
+  to_json(json &j, const Bottom_Front_Edge &) {
+    j = "bottom_front_edge";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Bottom_Front_Edge &) {
+    assert(j == "bottom_front_edge");
+  }
+  void
+  to_json(json &j, const Top_Back_Edge &) {
+    j = "top_back_edge";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Top_Back_Edge &) {
+    assert(j == "top_back_edge");
+  }
+  void
+  to_json(json &j, const Top_Front_Edge &) {
+    j = "top_front_edge";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Top_Front_Edge &) {
+    assert(j == "top_front_edge");
+  }
+
+  //
+  // ... Corners 3D
+  //
+
+  void
+  to_json(json &j, const Left_Bottom_Back_Corner &) {
+    j = "left_bottom_back_corner";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Left_Bottom_Back_Corner &) {
+    assert(j == "left_bottom_back_corner");
+  }
+  void
+  to_json(json &j, const Left_Bottom_Front_Corner &) {
+    j = "  left_bottom_front_corner";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Left_Bottom_Front_Corner &) {
+    assert(j == "  left_bottom_front_corner");
+  }
+  void
+  to_json(json &j, const Left_Top_Back_Corner &) {
+    j = "  left_top_back_corner";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Left_Top_Back_Corner &) {
+    assert(j == "  left_top_back_corner");
+  }
+  void
+  to_json(json &j, const Left_Top_Front_Corner &) {
+    j = "  left_top_front_corner";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Left_Top_Front_Corner &) {
+    assert(j == "  left_top_front_corner");
+  }
+  void
+  to_json(json &j, const Right_Bottom_Back_Corner &) {
+    j = "  right_bottom_back_corner";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Right_Bottom_Back_Corner &) {
+    assert(j == "  right_bottom_back_corner");
+  }
+  void
+  to_json(json &j, const Right_Bottom_Front_Corner &) {
+    j = "  right_bottom_front_corner";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Right_Bottom_Front_Corner &) {
+    assert(j == "  right_bottom_front_corner");
+  }
+  void
+  to_json(json &j, const Right_Top_Back_Corner &) {
+    j = "  right_top_back_corner";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Right_Top_Back_Corner &) {
+    assert(j == "  right_top_back_corner");
+  }
+  void
+  to_json(json &j, const Right_Top_Front_Corner &) {
+    j = "  right_top_front_corner";
+  }
+
+  void
+  from_json([[maybe_unused]] const json &j, Right_Top_Front_Corner &) {
+    assert(j == "  right_top_front_corner");
+  }
+
+} // end of namespace lbm::core

--- a/cxx/lbm/core/subdomain_tags.hpp
+++ b/cxx/lbm/core/subdomain_tags.hpp
@@ -1,10 +1,21 @@
 #pragma once
 
+//
+// ... LBM Bench header files
+//
+#include <lbm/core/import.hpp>
+
 namespace lbm::core {
 
+  //
+  // ... Interior
+  //
   struct Interior {
   } constexpr interior{};
 
+  //
+  // ... Boundaries 2D and 3D
+  //
   struct Left {
   } constexpr left{};
 
@@ -29,5 +40,312 @@ namespace lbm::core {
 
   template <class T>
   concept Boundary_Tag3 = Boundary_Tag2<T> || same_as<Back, T> || same_as<Front, T>;
+
+  //
+  // ... Corners 2D
+  //
+  struct Left_Bottom_Corner {
+  } constexpr left_bottom_corner{};
+
+  struct Left_Top_Corner {
+  } constexpr left_top_corner{};
+
+  struct Right_Bottom_Corner {
+  } constexpr right_bottom_corner{};
+
+  struct Right_Top_Corner {
+  } constexpr right_top_corner{};
+
+  template <class T>
+  concept Corner_Tag_2D = same_as<T, Left_Bottom_Corner> || same_as<T, Left_Top_Corner> ||
+      same_as<T, Right_Bottom_Corner> || same_as<T, Right_Top_Corner>;
+
+  //
+  // ... Edges on a three-dimensional grid
+  //
+  struct Left_Bottom_Edge {
+  } constexpr left_bottom_edge{};
+
+  struct Left_Top_Edge {
+  } constexpr left_top_edge{};
+
+  struct Right_Bottom_Edge {
+  } constexpr right_bottom_edge{};
+
+  struct Right_Top_Edge {
+  } constexpr right_top_Edge{};
+
+  struct Left_Back_Edge {
+  } constexpr left_back_Edge{};
+
+  struct Left_Front_Edge {
+  } constexpr left_front_edge{};
+
+  struct Right_Back_Edge {
+  } constexpr right_back_edge{};
+
+  struct Right_Front_Edge {
+  } constexpr right_front_edge{};
+
+  struct Bottom_Back_Edge {
+  } constexpr bottom_back_Edge{};
+
+  struct Bottom_Front_Edge {
+  } constexpr bottom_front_edge{};
+
+  struct Top_Back_Edge {
+  } constexpr top_back_edge{};
+
+  struct Top_Front_Edge {
+  } constexpr top_front_edge{};
+
+  template <class T>
+  concept Edge_Tag_3D =
+      same_as<T, Left_Bottom_Edge> || same_as<T, Left_Top_Edge> || same_as<T, Right_Bottom_Edge> ||
+      same_as<T, Right_Top_Edge> || same_as<T, Left_Back_Edge> || same_as<T, Left_Front_Edge> ||
+      same_as<T, Right_Back_Edge> || same_as<T, Right_Front_Edge> || same_as<T, Bottom_Back_Edge> ||
+      same_as<T, Bottom_Front_Edge> || same_as<T, Top_Back_Edge> || same_as<T, Top_Front_Edge>;
+
+  //
+  // ... Corners on a three-dimensional grid
+  //
+  struct Left_Bottom_Back_Corner {
+  } constexpr left_bottom_back_corner{};
+
+  struct Left_Bottom_Front_Corner {
+  } constexpr left_bottom_front_corner{};
+
+  struct Left_Top_Back_Corner {
+  } constexpr left_top_back_corner{};
+
+  struct Left_Top_Front_Corner {
+  } constexpr left_top_front_corner{};
+
+  struct Right_Bottom_Back_Corner {
+  } constexpr right_bottom_back_corner{};
+
+  struct Right_Bottom_Front_Corner {
+  } constexpr right_bottom_front_corner{};
+
+  struct Right_Top_Back_Corner {
+  } constexpr right_top_back_corner{};
+
+  struct Right_Top_Front_Corner {
+  } constexpr right_top_front_corner{};
+
+  template <class T>
+  concept Corner_Tag_3D =
+      same_as<T, Left_Bottom_Back_Corner> || same_as<T, Left_Bottom_Front_Corner> ||
+      same_as<T, Left_Top_Back_Corner> || same_as<T, Left_Top_Front_Corner> ||
+      same_as<T, Right_Bottom_Back_Corner> || same_as<T, Right_Bottom_Front_Corner> ||
+      same_as<T, Right_Top_Back_Corner> || same_as<T, Right_Top_Front_Corner>;
+
+  ////////////////////////////////////////////////////////////////////////
+  //
+  //  ... Serialization prototypes
+  //
+  //
+  // ... Interior
+  //
+  void
+  to_json(json &j, const Interior &);
+
+  void
+  from_json(const json &j, Interior &);
+
+  //
+  // ... Faces 2D and 3D
+  //
+
+  void
+  to_json(json &j, const Left &);
+
+  void
+  from_json(const json &j, Left &);
+
+  void
+  to_json(json &j, const Right &);
+
+  void
+  from_json(const json &j, Right &);
+
+  void
+  to_json(json &j, const Bottom &);
+
+  void
+  from_json(const json &j, Bottom &);
+
+  void
+  to_json(json &j, const Top &);
+
+  void
+  from_json(const json &j, Top &);
+
+  void
+  to_json(json &j, const Back &);
+
+  void
+  from_json(const json &j, Back &);
+
+  void
+  to_json(json &j, const Front &);
+
+  void
+  from_json(const json &j, Front &);
+
+  //
+  // ... Corners 2D
+  //
+  void
+  to_json(json &j, const Left_Bottom_Corner &);
+
+  void
+  from_json(const json &j, Left_Bottom_Corner &);
+
+  void
+  to_json(json &j, const Left_Top_Corner &);
+
+  void
+  from_json(const json &j, Left_Top_Corner &);
+
+  void
+  to_json(json &j, const Right_Bottom_Corner &);
+
+  void
+  from_json(const json &j, Right_Bottom_Corner &);
+
+  void
+  to_json(json &j, const Right_Top_Corner &);
+
+  void
+  from_json(const json &j, Right_Top_Corner &);
+
+  //
+  // ... Edges 3D
+  //
+
+  void
+  to_json(json &j, const Left_Bottom_Edge &);
+
+  void
+  from_json(const json &j, Left_Bottom_Edge &);
+
+  void
+  to_json(json &j, const Left_Top_Edge &);
+
+  void
+  from_json(const json &j, Left_Top_Edge &);
+
+  void
+  to_json(json &j, const Right_Bottom_Edge &);
+
+  void
+  from_json(const json &j, Right_Bottom_Edge &);
+
+  void
+  to_json(json &j, const Right_Top_Edge &);
+
+  void
+  from_json(const json &j, Right_Top_Edge &);
+
+  void
+  to_json(json &j, const Left_Back_Edge &);
+
+  void
+  from_json(const json &j, Left_Back_Edge &);
+
+  void
+  to_json(json &j, const Left_Front_Edge &);
+
+  void
+  from_json(const json &j, Left_Front_Edge &);
+
+  void
+  to_json(json &j, const Right_Back_Edge &);
+
+  void
+  from_json(const json &j, Right_Back_Edge &);
+
+  void
+  to_json(json &j, const Right_Front_Edge &);
+
+  void
+  from_json(const json &j, Right_Front_Edge &);
+
+  void
+  to_json(json &j, const Bottom_Back_Edge &);
+
+  void
+  from_json(const json &j, Bottom_Back_Edge &);
+
+  void
+  to_json(json &j, const Bottom_Front_Edge &);
+
+  void
+  from_json(const json &j, Bottom_Front_Edge &);
+
+  void
+  to_json(json &j, const Top_Back_Edge &);
+
+  void
+  from_json(const json &j, Top_Back_Edge &);
+
+  void
+  to_json(json &j, const Top_Front_Edge &);
+
+  void
+  from_json(const json &j, Top_Front_Edge &);
+
+  //
+  // ... Corners 3D
+  //
+
+  void
+  to_json(json &j, const Left_Bottom_Back_Corner &);
+
+  void
+  from_json(const json &j, Left_Bottom_Back_Corner &);
+
+  void
+  to_json(json &j, const Left_Bottom_Front_Corner &);
+
+  void
+  from_json(const json &j, Left_Bottom_Front_Corner &);
+
+  void
+  to_json(json &j, const Left_Top_Back_Corner &);
+
+  void
+  from_json(const json &j, Left_Top_Back_Corner &);
+
+  void
+  to_json(json &j, const Left_Top_Front_Corner &);
+
+  void
+  from_json(const json &j, Left_Top_Front_Corner &);
+
+  void
+  to_json(json &j, const Right_Bottom_Back_Corner &);
+
+  void
+  from_json(const json &j, Right_Bottom_Back_Corner &);
+
+  void
+  to_json(json &j, const Right_Bottom_Front_Corner &);
+
+  void
+  from_json(const json &j, Right_Bottom_Front_Corner &);
+
+  void
+  to_json(json &j, const Right_Top_Back_Corner &);
+
+  void
+  from_json(const json &j, Right_Top_Back_Corner &);
+
+  void
+  to_json(json &j, const Right_Top_Front_Corner &);
+
+  void
+  from_json(const json &j, Right_Top_Front_Corner &);
 
 } // end of namespace lbm::core

--- a/cxx/lbm/core/subdomain_tags.hpp
+++ b/cxx/lbm/core/subdomain_tags.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+namespace lbm::core {
+
+  struct Interior {
+  } constexpr interior{};
+
+  struct Left {
+  } constexpr left{};
+
+  struct Right {
+  } constexpr right{};
+
+  struct Bottom {
+  } constexpr bottom{};
+
+  struct Top {
+  } constexpr top{};
+
+  struct Back {
+  } constexpr back{};
+
+  struct Front {
+  } constexpr front{};
+
+  template <class T>
+  concept Boundary_Tag2 =
+      same_as<Left, T> || same_as<Right, T> || same_as<Bottom, T> || same_as<Top, T>;
+
+  template <class T>
+  concept Boundary_Tag3 = Boundary_Tag2<T> || same_as<Back, T> || same_as<Front, T>;
+
+} // end of namespace lbm::core

--- a/cxx/lbm/exceptions/Bad_Float_Type.hpp
+++ b/cxx/lbm/exceptions/Bad_Float_Type.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#pragma once
-
 //
 // ... LBM Bench header files
 //

--- a/cxx/lbm/exceptions/Unreachable.hpp
+++ b/cxx/lbm/exceptions/Unreachable.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+//
+// ... LBM Bench header files
+//
+#include <lbm/exceptions/import.hpp>
+
+namespace lbm::exceptions {
+
+  class Unreachable_Code : public logic_error {
+  public:
+    using logic_error::logic_error;
+  };
+
+  [[noreturn]] inline void
+  unreachable_code(source_location sloc) {
+    ostringstream ss{};
+    ss << sloc.file_name() << ":" << sloc.line() << ":0 Executing unreachable code";
+    throw Unreachable_Code{ss.str()};
+  }
+
+} // end of namespace lbm::exceptions

--- a/cxx/lbm/exceptions/import.hpp
+++ b/cxx/lbm/exceptions/import.hpp
@@ -3,10 +3,15 @@
 //
 // ... Standar header files
 //
+#include <source_location>
+#include <sstream>
 #include <stdexcept>
 
 namespace lbm::exceptions {
 
+  using std::logic_error;
+  using std::ostringstream;
   using std::runtime_error;
+  using std::source_location;
 
 } // end of namespace lbm::exceptions

--- a/cxx/lbm/utility.hpp
+++ b/cxx/lbm/utility.hpp
@@ -36,9 +36,9 @@ namespace lbm {
   using core::JSON_Convertible;
 
   using core::Array;
-  using core::Fixed_Array;
-  using core::Fixed_Array_Index;
   using core::Fixed_Lexical;
+  using core::Fixed_MD_Array;
+  using core::Fixed_MD_Array_Index;
   using core::Index;
   using core::integer;
   using core::json;

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(cxx)

--- a/examples/cxx/CMakeLists.txt
+++ b/examples/cxx/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(image_data_geometry_filter image_data_geometry_filter.cpp)
+target_link_libraries(image_data_geometry_filter PRIVATE ${VTK_LIBRARIES})
+
+add_executable(dem_reader dem_reader.cpp)
+target_link_libraries(dem_reader PRIVATE ${VTK_LIBRARIES})
+
+add_executable(image_map_to_colors image_map_to_colors.cpp)
+target_link_libraries(image_map_to_colors PRIVATE ${VTK_LIBRARIES})
+
+add_executable(image_mask image_mask.cpp)
+target_link_libraries(image_mask PRIVATE ${VTK_LIBRARIES})

--- a/examples/cxx/dem_reader.cpp
+++ b/examples/cxx/dem_reader.cpp
@@ -1,0 +1,70 @@
+#include <vtkDEMReader.h>
+#include <vtkImageActor.h>
+#include <vtkImageData.h>
+#include <vtkImageMapToColors.h>
+#include <vtkImageMapper3D.h>
+#include <vtkInteractorStyleImage.h>
+#include <vtkLookupTable.h>
+#include <vtkNamedColors.h>
+#include <vtkNew.h>
+#include <vtkProperty.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
+#include <vtkRenderer.h>
+
+int
+main(int argc, char *argv[]) {
+  vtkNew<vtkNamedColors> colors;
+
+  // Verify arguments.
+  if (argc < 2) {
+    std::cerr << "Required: filename.dem e.g. SainteHelens.dem" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Read the file
+  vtkNew<vtkDEMReader> reader;
+  reader->SetFileName(argv[1]);
+  reader->Update();
+
+  vtkNew<vtkLookupTable> lut;
+  lut->SetHueRange(0.6, 0);
+  lut->SetSaturationRange(1.0, 0);
+  lut->SetValueRange(0.5, 1.0);
+  lut->SetTableRange(reader->GetOutput()->GetScalarRange());
+
+  // Visualize
+  vtkNew<vtkImageMapToColors> mapColors;
+  mapColors->SetLookupTable(lut);
+  mapColors->SetInputConnection(reader->GetOutputPort());
+
+  // Create an actor.
+  vtkNew<vtkImageActor> actor;
+  actor->GetMapper()->SetInputConnection(mapColors->GetOutputPort());
+
+  // Setup renderer.
+  vtkNew<vtkRenderer> renderer;
+  renderer->AddActor(actor);
+  renderer->ResetCamera();
+  renderer->SetBackground(colors->GetColor3d("SlateGray").GetData());
+
+  // Setup render window.
+  vtkNew<vtkRenderWindow> renderWindow;
+  renderWindow->AddRenderer(renderer);
+  renderWindow->SetWindowName("DEMReader");
+
+  // Setup render window interactor.
+  vtkNew<vtkRenderWindowInteractor> renderWindowInteractor;
+  vtkNew<vtkInteractorStyleImage> style;
+
+  renderWindowInteractor->SetInteractorStyle(style);
+
+  // Render and start interaction.
+  renderWindowInteractor->SetRenderWindow(renderWindow);
+  renderWindow->Render();
+  renderWindowInteractor->Initialize();
+
+  renderWindowInteractor->Start();
+
+  return EXIT_SUCCESS;
+}

--- a/examples/cxx/image_data_geometry_filter.cpp
+++ b/examples/cxx/image_data_geometry_filter.cpp
@@ -1,0 +1,69 @@
+#include <vtkActor.h>
+#include <vtkImageCanvasSource2D.h>
+#include <vtkImageData.h>
+#include <vtkImageDataGeometryFilter.h>
+#include <vtkNamedColors.h>
+#include <vtkNew.h>
+#include <vtkPolyDataMapper.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
+#include <vtkRenderer.h>
+#include <vtkSphereSource.h>
+
+#include <array>
+
+int
+main(int, char *[]) {
+  vtkNew<vtkNamedColors> colors;
+
+  // Convert our unsigned char colors to doubles
+  // Set draw color needs doubles.
+  auto color1 = colors->GetColor4ub("SteelBlue").GetData();
+  auto color2 = colors->GetColor4ub("PaleGoldenrod").GetData();
+  std::array<double, 4> sourceColor1{0, 0, 0, 0};
+  std::array<double, 4> sourceColor2{0, 0, 0, 0};
+  for (auto i = 0; i < 4; ++i) {
+    sourceColor1[i] = color1[i];
+    sourceColor2[i] = color2[i];
+  }
+
+  // Create an image
+  vtkNew<vtkImageCanvasSource2D> source1;
+  source1->SetScalarTypeToUnsignedChar();
+  source1->SetNumberOfScalarComponents(3);
+  source1->SetExtent(0, 100, 0, 100, 0, 0);
+  source1->SetDrawColor(sourceColor1.data());
+  source1->FillBox(0, 100, 0, 100);
+  source1->SetDrawColor(sourceColor2.data());
+  source1->FillBox(10, 20, 10, 20);
+  source1->FillBox(40, 50, 20, 30);
+  source1->Update();
+
+  // Convert the image to a polydata
+  vtkNew<vtkImageDataGeometryFilter> imageDataGeometryFilter;
+  imageDataGeometryFilter->SetInputConnection(source1->GetOutputPort());
+  imageDataGeometryFilter->Update();
+
+  // Create a mapper and actor
+  vtkNew<vtkPolyDataMapper> mapper;
+  mapper->SetInputConnection(imageDataGeometryFilter->GetOutputPort());
+
+  vtkNew<vtkActor> actor;
+  actor->SetMapper(mapper);
+
+  // Visualization
+  vtkNew<vtkRenderer> renderer;
+  vtkNew<vtkRenderWindow> renderWindow;
+  renderWindow->AddRenderer(renderer);
+  vtkNew<vtkRenderWindowInteractor> renderWindowInteractor;
+  renderWindowInteractor->SetRenderWindow(renderWindow);
+
+  renderer->AddActor(actor);
+  renderer->SetBackground(colors->GetColor3d("RosyBrown").GetData());
+
+  renderWindow->SetWindowName("ImageDataGeometryFilter");
+  renderWindow->Render();
+  renderWindowInteractor->Start();
+
+  return EXIT_SUCCESS;
+}

--- a/examples/cxx/image_map_to_colors.cpp
+++ b/examples/cxx/image_map_to_colors.cpp
@@ -1,0 +1,78 @@
+//
+// Displays a "grayscale" image as a full color image via the
+// vtkImageMapToColors filter, which uses a lookup table to
+// map scalar values to colors
+//
+#include <vtkImageActor.h>
+#include <vtkImageData.h>
+#include <vtkImageMapToColors.h>
+#include <vtkImageMapper3D.h>
+#include <vtkImageProperty.h>
+#include <vtkInteractorStyleImage.h>
+#include <vtkLookupTable.h>
+#include <vtkNamedColors.h>
+#include <vtkNew.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
+#include <vtkRenderer.h>
+
+int
+main(int, char *[]) {
+  vtkNew<vtkNamedColors> colors;
+
+  // Create a "grayscale" 16x16 image, 1-component pixels of type "double".
+  vtkNew<vtkImageData> image;
+  int imageExtent[6] = {0, 150, 0, 150, 0, 0};
+  image->SetExtent(imageExtent);
+  image->AllocateScalars(VTK_DOUBLE, 1);
+
+  double scalarvalue = 0.0;
+
+  for (int y = imageExtent[2]; y <= imageExtent[3]; y++) {
+    for (int x = imageExtent[0]; x <= imageExtent[1]; x++) {
+      double *pixel = static_cast<double *>(image->GetScalarPointer(x, y, 0));
+      pixel[0] = scalarvalue;
+      scalarvalue += 1.0;
+    }
+  }
+
+  // Map the scalar values in the image to colors with a lookup table:
+  vtkNew<vtkLookupTable> lookupTable;
+  lookupTable->SetNumberOfTableValues(256);
+  lookupTable->SetRange(0.0, 255.0);
+  lookupTable->Build();
+
+  // Pass the original image and the lookup table to a filter to create
+  // a color image:
+  vtkNew<vtkImageMapToColors> scalarValuesToColors;
+  scalarValuesToColors->SetLookupTable(lookupTable);
+  scalarValuesToColors->PassAlphaToOutputOn();
+  scalarValuesToColors->SetInputData(image);
+
+  // Create an image actor.
+  vtkNew<vtkImageActor> imageActor;
+  imageActor->GetMapper()->SetInputConnection(scalarValuesToColors->GetOutputPort());
+  imageActor->GetProperty()->SetInterpolationTypeToNearest();
+
+  // Visualize.
+  vtkNew<vtkRenderer> renderer;
+  renderer->AddActor(imageActor);
+  renderer->ResetCamera();
+  renderer->SetBackground(colors->GetColor3d("SlateGray").GetData());
+
+  vtkNew<vtkRenderWindow> renderWindow;
+  renderWindow->AddRenderer(renderer);
+  renderWindow->SetWindowName("ImageMapToColors");
+
+  vtkNew<vtkRenderWindowInteractor> renderWindowInteractor;
+  vtkNew<vtkInteractorStyleImage> style;
+
+  renderWindowInteractor->SetInteractorStyle(style);
+
+  renderWindowInteractor->SetRenderWindow(renderWindow);
+  renderWindow->Render();
+  renderWindowInteractor->Initialize();
+  renderWindowInteractor->Start();
+
+  return EXIT_SUCCESS;
+}

--- a/examples/cxx/image_mask.cpp
+++ b/examples/cxx/image_mask.cpp
@@ -1,0 +1,125 @@
+#include <vtkImageActor.h>
+#include <vtkImageCanvasSource2D.h>
+#include <vtkImageMapper3D.h>
+#include <vtkImageMask.h>
+#include <vtkInteractorStyleImage.h>
+#include <vtkNamedColors.h>
+#include <vtkNew.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
+#include <vtkRenderer.h>
+
+int
+main(int, char *[]) {
+  vtkNew<vtkNamedColors> colors;
+
+  // Create an image of a rectangle.
+  vtkNew<vtkImageCanvasSource2D> source;
+  source->SetScalarTypeToUnsignedChar();
+  source->SetNumberOfScalarComponents(3);
+  source->SetExtent(0, 200, 0, 200, 0, 0);
+
+  // Create a red image.
+  source->SetDrawColor(255, 0, 0);
+  source->FillBox(0, 200, 0, 200);
+
+  source->Update();
+
+  // Create a rectanglular mask.
+  vtkNew<vtkImageCanvasSource2D> maskSource;
+  maskSource->SetScalarTypeToUnsignedChar();
+  maskSource->SetNumberOfScalarComponents(1);
+  maskSource->SetExtent(0, 200, 0, 200, 0, 0);
+
+  // Initialize the mask to black.
+  maskSource->SetDrawColor(0, 0, 0);
+  maskSource->FillBox(0, 200, 0, 200);
+
+  // Create a square.
+  maskSource->SetDrawColor(255,
+                           255,
+                           255); // Anything non-zero means "make the output
+                                 // pixel equal the input pixel". If the mask is
+                                 // zero, the output pixel is set to MaskedValue.
+  maskSource->FillBox(100, 120, 100, 120);
+  maskSource->Update();
+
+  vtkNew<vtkImageMask> maskFilter;
+  maskFilter->SetInputConnection(0, source->GetOutputPort());
+  maskFilter->SetInputConnection(1, maskSource->GetOutputPort());
+  maskFilter->SetMaskedOutputValue(0, 1, 0);
+  maskFilter->Update();
+
+  vtkNew<vtkImageMask> inverseMaskFilter;
+  inverseMaskFilter->SetInputConnection(0, source->GetOutputPort());
+  inverseMaskFilter->SetInputConnection(1, maskSource->GetOutputPort());
+  inverseMaskFilter->SetMaskedOutputValue(0, 1, 0);
+  inverseMaskFilter->NotMaskOn();
+  inverseMaskFilter->Update();
+
+  // Create actors.
+  vtkNew<vtkImageActor> originalActor;
+  originalActor->GetMapper()->SetInputConnection(source->GetOutputPort());
+
+  vtkNew<vtkImageActor> maskActor;
+  maskActor->GetMapper()->SetInputConnection(maskSource->GetOutputPort());
+
+  vtkNew<vtkImageActor> maskedActor;
+  maskedActor->GetMapper()->SetInputConnection(maskFilter->GetOutputPort());
+
+  vtkNew<vtkImageActor> inverseMaskedActor;
+  inverseMaskedActor->GetMapper()->SetInputConnection(inverseMaskFilter->GetOutputPort());
+
+  // Define viewport ranges.
+  // (xmin, ymin, xmax, ymax)
+  double originalViewport[4] = {0.0, 0.0, 0.25, 1.0};
+  double maskViewport[4] = {0.25, 0.0, 0.5, 1.0};
+  double maskedViewport[4] = {0.5, 0.0, 0.75, 1.0};
+  double inverseMaskedViewport[4] = {0.75, 0.0, 1.0, 1.0};
+
+  // Setup renderers.
+  vtkNew<vtkRenderer> originalRenderer;
+  originalRenderer->SetViewport(originalViewport);
+  originalRenderer->AddActor(originalActor);
+  originalRenderer->ResetCamera();
+  originalRenderer->SetBackground(colors->GetColor3d("SandyBrown").GetData());
+
+  vtkNew<vtkRenderer> maskRenderer;
+  maskRenderer->SetViewport(maskViewport);
+  maskRenderer->AddActor(maskActor);
+  maskRenderer->ResetCamera();
+  maskRenderer->SetBackground(colors->GetColor3d("Peru").GetData());
+
+  vtkNew<vtkRenderer> maskedRenderer;
+  maskedRenderer->SetViewport(maskedViewport);
+  maskedRenderer->AddActor(maskedActor);
+  maskedRenderer->ResetCamera();
+  maskedRenderer->SetBackground(colors->GetColor3d("SandyBrown").GetData());
+
+  vtkNew<vtkRenderer> inverseMaskedRenderer;
+  inverseMaskedRenderer->SetViewport(inverseMaskedViewport);
+  inverseMaskedRenderer->AddActor(inverseMaskedActor);
+  inverseMaskedRenderer->ResetCamera();
+  inverseMaskedRenderer->SetBackground(colors->GetColor3d("Peru").GetData());
+
+  vtkNew<vtkRenderWindow> renderWindow;
+  renderWindow->SetSize(1000, 250);
+  renderWindow->AddRenderer(originalRenderer);
+  renderWindow->AddRenderer(maskRenderer);
+  renderWindow->AddRenderer(maskedRenderer);
+  renderWindow->AddRenderer(inverseMaskedRenderer);
+  renderWindow->SetWindowName("ImageMask");
+
+  vtkNew<vtkRenderWindowInteractor> renderWindowInteractor;
+  vtkNew<vtkInteractorStyleImage> style;
+
+  renderWindowInteractor->SetInteractorStyle(style);
+
+  renderWindowInteractor->SetRenderWindow(renderWindow);
+  renderWindow->Render();
+  renderWindowInteractor->Initialize();
+
+  renderWindowInteractor->Start();
+
+  return EXIT_SUCCESS;
+}

--- a/test/cxx/CMakeLists.txt
+++ b/test/cxx/CMakeLists.txt
@@ -15,6 +15,7 @@ macro(lbmbench_add_test test_name)
 endmacro()
 
 lbmbench_add_test(array)
+lbmbench_add_test(array2)
 lbmbench_add_test(boundary_condition)
 lbmbench_add_test(boundary_id)
 lbmbench_add_test(bounding_box)

--- a/test/cxx/D2Q9_array2_test.cpp
+++ b/test/cxx/D2Q9_array2_test.cpp
@@ -1,0 +1,51 @@
+//
+// ... LBM Bench header files
+//
+#include <lbm/D2Q9/Array2.hpp>
+
+//
+// ... Testing header files
+//
+#include <catch2/catch_test_macros.hpp>
+
+namespace lbm::D2Q9::testing {
+
+  TEST_CASE("Node Array") {
+    using enum Boundary_ID;
+    constexpr size_type nx = 2;
+    constexpr size_type ny = 3;
+    constexpr size_type nxm1 = nx - 1;
+    constexpr size_type nym1 = ny - 1;
+    Array2<int> array{Lexical{Shape{nx, ny}}};
+    std::fill(std::begin(array), std::end(array), 0);
+
+    SECTION("Left Boundary Iterator") {
+      std::fill(array.begin<Left>(), array.end<Left>(), 1);
+      for (size_type j = 1; j < nym1; ++j) {
+        CHECK(array(0, j) == 1);
+      }
+    }
+
+    SECTION("Right Boundary Iterator") {
+      std::fill(array.begin<Right>(), array.end<Right>(), 1);
+      for (size_type j = 1; j < nym1; ++j) {
+        CHECK(array(nxm1, j) == 1);
+      }
+    }
+
+    SECTION("Bottom Boundary Iterator") {
+      std::fill(array.begin<Bottom>(), array.end<Bottom>(), 1);
+      for (size_type i = 1; i < nxm1; ++i) {
+        CHECK(array(i, 0) == 1);
+      }
+    }
+
+    SECTION("Top Boundary Iterator") {
+      std::fill(array.begin<Bottom>(), array.end<Bottom>(), 1);
+      for (size_type i = 1; i < nxm1; ++i) {
+        CHECK(array(i, nym1) == 1);
+      }
+    }
+  }
+
+} // end of namespace lbm::D2Q9::testing

--- a/test/cxx/D2Q9_state_test.cpp
+++ b/test/cxx/D2Q9_state_test.cpp
@@ -1,4 +1,4 @@
-// ega
+//
 //  ... LBM Bench
 //
 #include <lbm/D2Q9/State.hpp>
@@ -29,7 +29,9 @@ namespace lbm::D2Q9::testing {
     constexpr double width = 200.0;
     constexpr double height = 100.0;
     constexpr double lattice_spacing = 5.0;
+    constexpr double inlet_density = 1.0;
     constexpr double inlet_speed = 4.0;
+    constexpr double outlet_density = 1.0;
     constexpr double outlet_speed = 4.0;
     constexpr double radius = 5.0;
     const Euclidean velocity{u0, v0};
@@ -44,8 +46,8 @@ namespace lbm::D2Q9::testing {
         num_steps,
         Lattice{Bounding_Box{width, height}, lattice_spacing},
         Initial_Conditions{Initial_Density{density}, Initial_Velocity{constant(u0), constant(v0)}},
-        Boundary_Conditions{Inlet{Boundary_ID::Left, inlet_speed},
-                            Outlet{Boundary_ID::Right, outlet_speed},
+        Boundary_Conditions{Inlet{Boundary_ID::Left, inlet_density, inlet_speed},
+                            Outlet{Boundary_ID::Right, outlet_density, outlet_speed},
                             Wall{Boundary_ID::Bottom},
                             Wall{Boundary_ID::Top}},
         Obstacles{square(radius) - (square(x - center0[0]) + square(y - center0[1])),

--- a/test/cxx/D2Q9_state_test.cpp
+++ b/test/cxx/D2Q9_state_test.cpp
@@ -28,7 +28,7 @@ namespace lbm::D2Q9::testing {
     constexpr double v0 = 3.0;
     constexpr double width = 200.0;
     constexpr double height = 100.0;
-    constexpr double lattice_spacing = 5.0;
+    constexpr double lattice_spacing = 50.0;
     constexpr double inlet_density = 1.0;
     constexpr double inlet_speed = 4.0;
     constexpr double outlet_density = 1.0;
@@ -57,6 +57,7 @@ namespace lbm::D2Q9::testing {
 
     SECTION("Conversion to and from JSON") {
       json json_state = state;
+
       State<double> state_from_json = json_state;
       CHECK(state == state_from_json);
     }

--- a/test/cxx/D2Q9_velocity_distribution_test.cpp
+++ b/test/cxx/D2Q9_velocity_distribution_test.cpp
@@ -48,5 +48,12 @@ namespace lbm::core::testing {
       REQUIRE_THAT(dist_velocity[0], Catch::Matchers::WithinAbs(velocity[0], 1.0E-12));
       REQUIRE_THAT(dist_velocity[1], Catch::Matchers::WithinAbs(velocity[1], 1.0E-12));
     }
+
+    SECTION("Compute nonequilibrium part") {
+      constexpr auto nedist = dist.nonequilibrium();
+      for_each(nedist.begin(), nedist.end(), [](auto f) {
+        REQUIRE_THAT(f, Catch::Matchers::WithinAbs(0.0, 1.0E-12));
+      });
+    }
   }
 } // namespace lbm::core::testing

--- a/test/cxx/array2_test.cpp
+++ b/test/cxx/array2_test.cpp
@@ -21,20 +21,20 @@ namespace lbm::core::testing {
     std::fill(std::begin(array), std::end(array), 0);
 
     SECTION("Left Boundary Iterator") {
-      std::fill(array.begin<Left>(), array.end<Left>(), 1);
+      std::fill(array.begin(left), array.end(left), 1);
       for (size_type j = 1; j < nym1; ++j) {
         CHECK(array(0, j) == 1);
       }
 
-      std::for_each(array.cbegin<Right>(), array.cend<Right>(), [&](auto elem) {
+      std::for_each(array.cbegin(right), array.cend(right), [&](auto elem) {
         CHECK(static_cast<const int &>(elem) == 0);
       });
 
-      std::for_each(array.cbegin<Bottom>(), array.cend<Bottom>(), [&](auto elem) {
+      std::for_each(array.cbegin(bottom), array.cend(bottom), [&](auto elem) {
         CHECK(static_cast<const int &>(elem) == 0);
       });
 
-      std::for_each(array.cbegin<Top>(), array.cend<Top>(), [&](auto elem) {
+      std::for_each(array.cbegin(top), array.cend(top), [&](auto elem) {
         CHECK(static_cast<const int &>(elem) == 0);
       });
 
@@ -43,20 +43,20 @@ namespace lbm::core::testing {
     }
 
     SECTION("Right Boundary Iterator") {
-      std::fill(array.begin<Right>(), array.end<Right>(), 1);
+      std::fill(array.begin(right), array.end(right), 1);
       for (size_type j = 1; j < nym1; ++j) {
         CHECK(array(nxm1, j) == 1);
       }
 
-      std::for_each(array.cbegin<Left>(), array.cend<Left>(), [&](auto elem) {
+      std::for_each(array.cbegin(left), array.cend(left), [&](auto elem) {
         CHECK(static_cast<const int &>(elem) == 0);
       });
 
-      std::for_each(array.cbegin<Bottom>(), array.cend<Bottom>(), [&](auto elem) {
+      std::for_each(array.cbegin(bottom), array.cend(bottom), [&](auto elem) {
         CHECK(static_cast<const int &>(elem) == 0);
       });
 
-      std::for_each(array.cbegin<Top>(), array.cend<Top>(), [&](auto elem) {
+      std::for_each(array.cbegin(top), array.cend(top), [&](auto elem) {
         CHECK(static_cast<const int &>(elem) == 0);
       });
       std::for_each(
@@ -64,20 +64,20 @@ namespace lbm::core::testing {
     }
 
     SECTION("Bottom Boundary Iterator") {
-      std::fill(array.begin<Bottom>(), array.end<Bottom>(), 1);
+      std::fill(array.begin(bottom), array.end(bottom), 1);
       for (size_type i = 1; i < nxm1; ++i) {
         CHECK(array(i, 0) == 1);
       }
 
-      std::for_each(array.cbegin<Right>(), array.cend<Right>(), [&](auto elem) {
+      std::for_each(array.cbegin(right), array.cend(right), [&](auto elem) {
         CHECK(static_cast<const int &>(elem) == 0);
       });
 
-      std::for_each(array.cbegin<Left>(), array.cend<Left>(), [&](auto elem) {
+      std::for_each(array.cbegin(left), array.cend(left), [&](auto elem) {
         CHECK(static_cast<const int &>(elem) == 0);
       });
 
-      std::for_each(array.cbegin<Top>(), array.cend<Top>(), [&](auto elem) {
+      std::for_each(array.cbegin(top), array.cend(top), [&](auto elem) {
         CHECK(static_cast<const int &>(elem) == 0);
       });
 
@@ -86,21 +86,21 @@ namespace lbm::core::testing {
     }
 
     SECTION("Top Boundary Iterator") {
-      std::fill(array.begin<Top>(), array.end<Top>(), 1);
+      std::fill(array.begin(top), array.end(top), 1);
       for (size_type i = 1; i < nxm1; ++i) {
         std::cout << "i: " << i << std::endl;
         CHECK(array(i, nym1) == 1);
       }
 
-      std::for_each(array.cbegin<Right>(), array.cend<Right>(), [&](auto elem) {
+      std::for_each(array.cbegin(right), array.cend(right), [&](auto elem) {
         CHECK(static_cast<const int &>(elem) == 0);
       });
 
-      std::for_each(array.cbegin<Left>(), array.cend<Left>(), [&](auto elem) {
+      std::for_each(array.cbegin(left), array.cend(left), [&](auto elem) {
         CHECK(static_cast<const int &>(elem) == 0);
       });
 
-      std::for_each(array.cbegin<Bottom>(), array.cend<Bottom>(), [&](auto elem) {
+      std::for_each(array.cbegin(bottom), array.cend(bottom), [&](auto elem) {
         CHECK(static_cast<const int &>(elem) == 0);
       });
 
@@ -116,25 +116,25 @@ namespace lbm::core::testing {
         }
       }
 
-      std::for_each(array.cbegin<Right>(), array.cend<Right>(), [&](auto elem) {
+      std::for_each(array.cbegin(right), array.cend(right), [&](auto elem) {
         CHECK(static_cast<const int &>(elem) == 0);
       });
 
-      std::for_each(array.cbegin<Left>(), array.cend<Left>(), [&](auto elem) {
+      std::for_each(array.cbegin(left), array.cend(left), [&](auto elem) {
         CHECK(static_cast<const int &>(elem) == 0);
       });
 
-      std::for_each(array.cbegin<Bottom>(), array.cend<Bottom>(), [&](auto elem) {
+      std::for_each(array.cbegin(bottom), array.cend(bottom), [&](auto elem) {
         CHECK(static_cast<const int &>(elem) == 0);
       });
 
-      std::for_each(array.cbegin<Top>(), array.cend<Top>(), [&](auto elem) {
+      std::for_each(array.cbegin(top), array.cend(top), [&](auto elem) {
         CHECK(static_cast<const int &>(elem) == 0);
       });
     }
 
     SECTION("Forall function") {
-      forall(array.begin<Left>(), array.end<Left>(), [](auto it) { it(1, 0) = 1; });
+      forall(array.begin(left), array.end(left), [](auto it) { it(1, 0) = 1; });
       for (size_type j = 1; j < nym1; ++j) {
         CHECK(array(1, j) == 1);
       }

--- a/test/cxx/array2_test.cpp
+++ b/test/cxx/array2_test.cpp
@@ -1,0 +1,144 @@
+//
+// ... LBM Bench header files
+//
+#include <lbm/core/Array2.hpp>
+#include <lbm/core/forall.hpp>
+
+//
+// ... Testing header files
+//
+#include <catch2/catch_test_macros.hpp>
+
+namespace lbm::core::testing {
+
+  TEST_CASE("Node Array") {
+    using enum Boundary_ID;
+    constexpr size_type nx = 4;
+    constexpr size_type ny = 5;
+    constexpr size_type nxm1 = nx - 1;
+    constexpr size_type nym1 = ny - 1;
+    Array2<int> array{Lexical{Shape{nx, ny}}, 0};
+    std::fill(std::begin(array), std::end(array), 0);
+
+    SECTION("Left Boundary Iterator") {
+      std::fill(array.begin<Left>(), array.end<Left>(), 1);
+      for (size_type j = 1; j < nym1; ++j) {
+        CHECK(array(0, j) == 1);
+      }
+
+      std::for_each(array.cbegin<Right>(), array.cend<Right>(), [&](auto elem) {
+        CHECK(static_cast<const int &>(elem) == 0);
+      });
+
+      std::for_each(array.cbegin<Bottom>(), array.cend<Bottom>(), [&](auto elem) {
+        CHECK(static_cast<const int &>(elem) == 0);
+      });
+
+      std::for_each(array.cbegin<Top>(), array.cend<Top>(), [&](auto elem) {
+        CHECK(static_cast<const int &>(elem) == 0);
+      });
+
+      std::for_each(
+          array.cbegin(interior), array.cend(interior), [](auto elem) { CHECK(elem == 0); });
+    }
+
+    SECTION("Right Boundary Iterator") {
+      std::fill(array.begin<Right>(), array.end<Right>(), 1);
+      for (size_type j = 1; j < nym1; ++j) {
+        CHECK(array(nxm1, j) == 1);
+      }
+
+      std::for_each(array.cbegin<Left>(), array.cend<Left>(), [&](auto elem) {
+        CHECK(static_cast<const int &>(elem) == 0);
+      });
+
+      std::for_each(array.cbegin<Bottom>(), array.cend<Bottom>(), [&](auto elem) {
+        CHECK(static_cast<const int &>(elem) == 0);
+      });
+
+      std::for_each(array.cbegin<Top>(), array.cend<Top>(), [&](auto elem) {
+        CHECK(static_cast<const int &>(elem) == 0);
+      });
+      std::for_each(
+          array.cbegin(interior), array.cend(interior), [](auto elem) { CHECK(elem == 0); });
+    }
+
+    SECTION("Bottom Boundary Iterator") {
+      std::fill(array.begin<Bottom>(), array.end<Bottom>(), 1);
+      for (size_type i = 1; i < nxm1; ++i) {
+        CHECK(array(i, 0) == 1);
+      }
+
+      std::for_each(array.cbegin<Right>(), array.cend<Right>(), [&](auto elem) {
+        CHECK(static_cast<const int &>(elem) == 0);
+      });
+
+      std::for_each(array.cbegin<Left>(), array.cend<Left>(), [&](auto elem) {
+        CHECK(static_cast<const int &>(elem) == 0);
+      });
+
+      std::for_each(array.cbegin<Top>(), array.cend<Top>(), [&](auto elem) {
+        CHECK(static_cast<const int &>(elem) == 0);
+      });
+
+      std::for_each(
+          array.cbegin(interior), array.cend(interior), [](auto elem) { CHECK(elem == 0); });
+    }
+
+    SECTION("Top Boundary Iterator") {
+      std::fill(array.begin<Top>(), array.end<Top>(), 1);
+      for (size_type i = 1; i < nxm1; ++i) {
+        std::cout << "i: " << i << std::endl;
+        CHECK(array(i, nym1) == 1);
+      }
+
+      std::for_each(array.cbegin<Right>(), array.cend<Right>(), [&](auto elem) {
+        CHECK(static_cast<const int &>(elem) == 0);
+      });
+
+      std::for_each(array.cbegin<Left>(), array.cend<Left>(), [&](auto elem) {
+        CHECK(static_cast<const int &>(elem) == 0);
+      });
+
+      std::for_each(array.cbegin<Bottom>(), array.cend<Bottom>(), [&](auto elem) {
+        CHECK(static_cast<const int &>(elem) == 0);
+      });
+
+      std::for_each(
+          array.cbegin(interior), array.cend(interior), [](auto elem) { CHECK(elem == 0); });
+    }
+
+    SECTION("Interior Iterator") {
+      std::fill(array.begin(interior), array.end(interior), 1);
+      for (size_type i = 1; i < nxm1; ++i) {
+        for (size_type j = 1; j < nym1; ++j) {
+          CHECK(array(i, j) == 1);
+        }
+      }
+
+      std::for_each(array.cbegin<Right>(), array.cend<Right>(), [&](auto elem) {
+        CHECK(static_cast<const int &>(elem) == 0);
+      });
+
+      std::for_each(array.cbegin<Left>(), array.cend<Left>(), [&](auto elem) {
+        CHECK(static_cast<const int &>(elem) == 0);
+      });
+
+      std::for_each(array.cbegin<Bottom>(), array.cend<Bottom>(), [&](auto elem) {
+        CHECK(static_cast<const int &>(elem) == 0);
+      });
+
+      std::for_each(array.cbegin<Top>(), array.cend<Top>(), [&](auto elem) {
+        CHECK(static_cast<const int &>(elem) == 0);
+      });
+    }
+
+    SECTION("Forall function") {
+      forall(array.begin<Left>(), array.end<Left>(), [](auto it) { it(1, 0) = 1; });
+      for (size_type j = 1; j < nym1; ++j) {
+        CHECK(array(1, j) == 1);
+      }
+    }
+  }
+
+} // namespace lbm::core::testing

--- a/test/cxx/array_test.cpp
+++ b/test/cxx/array_test.cpp
@@ -20,10 +20,11 @@ namespace lbm::core::testing {
     MD_Array<double, 2> array{Lexical{Shape{nx, ny}}};
 
     SECTION("element access") {
+      auto mutable_array = array;
       for (size_type i = 0; i < nx; ++i) {
         for (size_type j = 0; j < ny; ++j) {
           CHECK(array(i, j) == 0.0);
-          CHECK(&array(i, j) == &array(Index{i, j}));
+          CHECK(array(i, j) == array(Index{i, j}));
           array(i, j) = i * ny + j;
         }
       }
@@ -36,8 +37,13 @@ namespace lbm::core::testing {
     }
 
     SECTION("conversion to and from JSON") {
+      std::cout << "************************************************************************"
+                << std::endl;
       nlohmann::json json_array = array;
       MD_Array<double, 2> array_from_json = json_array;
+      std::cout << "array           = " << array << std::endl;
+      std::cout << "json_array      = " << json_array << std::endl;
+      std::cout << "array_from_json = " << array_from_json << std::endl;
       CHECK(array == array_from_json);
     }
 

--- a/test/cxx/array_test.cpp
+++ b/test/cxx/array_test.cpp
@@ -14,10 +14,10 @@
 #include <sstream>
 
 namespace lbm::core::testing {
-  TEST_CASE("Array") {
+  TEST_CASE("MD_Array") {
     constexpr size_type nx = 2;
     constexpr size_type ny = 3;
-    Array<double, 2> array{Lexical{Shape{nx, ny}}};
+    MD_Array<double, 2> array{Lexical{Shape{nx, ny}}};
 
     SECTION("element access") {
       for (size_type i = 0; i < nx; ++i) {
@@ -37,14 +37,14 @@ namespace lbm::core::testing {
 
     SECTION("conversion to and from JSON") {
       nlohmann::json json_array = array;
-      Array<double, 2> array_from_json = json_array;
+      MD_Array<double, 2> array_from_json = json_array;
       CHECK(array == array_from_json);
     }
 
     SECTION("conversion to and from text") {
       std::stringstream ss;
       ss << array;
-      Array<double, 2> array_from_text{};
+      MD_Array<double, 2> array_from_text{};
       ss >> array_from_text;
     }
   }

--- a/test/cxx/boundary_condition_test.cpp
+++ b/test/cxx/boundary_condition_test.cpp
@@ -56,8 +56,10 @@ namespace lbm::core {
     }
 
     SECTION("Inlet") {
-      Boundary_ID south = Bottom;
-      Boundary_Condition boundary_condition{Inlet{south, 3.0}};
+      constexpr Boundary_ID south = Bottom;
+      constexpr double density = 1.0;
+      constexpr double speed = 3.0;
+      Boundary_Condition boundary_condition{Inlet{south, density, speed}};
       SECTION("Conversion to and from json") {
         json json_boundary_condition = boundary_condition;
         std::cout << json_boundary_condition << std::endl;
@@ -72,11 +74,16 @@ namespace lbm::core {
         CHECK(boundary_condition_from_text == boundary_condition);
       }
       SECTION("Boundary ID access") { CHECK(boundary_condition.boundary() == south); }
+      SECTION("Density access") { CHECK(std::get<Inlet>(boundary_condition).density() == density); }
+      SECTION("Speed access") { CHECK(std::get<Inlet>(boundary_condition).speed() == speed); }
     }
 
     SECTION("Outlet") {
-      Boundary_ID south = Bottom;
-      Boundary_Condition boundary_condition{Outlet{south, 3.0}};
+      constexpr Boundary_ID south = Bottom;
+      constexpr double density = 1.0;
+      constexpr double speed = 3.0;
+      Boundary_Condition boundary_condition{Outlet{south, density, speed}};
+
       SECTION("Conversion to and from json") {
         json json_boundary_condition = boundary_condition;
         Boundary_Condition boundary_condition_from_json = json_boundary_condition;
@@ -90,6 +97,10 @@ namespace lbm::core {
         CHECK(boundary_condition_from_text == boundary_condition);
       }
       SECTION("Boundary ID access") { CHECK(boundary_condition.boundary() == south); }
+      SECTION("Density access") {
+        CHECK(std::get<Outlet>(boundary_condition).density() == density);
+      }
+      SECTION("Speed access") { CHECK(std::get<Outlet>(boundary_condition).speed() == speed); }
     }
 
     SECTION("Pressure Drop") {

--- a/test/cxx/boundary_condition_test.cpp
+++ b/test/cxx/boundary_condition_test.cpp
@@ -39,12 +39,14 @@ namespace lbm::core {
     SECTION("Symmetry") {
       Boundary_ID north = Top;
       Boundary_Condition boundary_condition{Symmetry{north}};
+
       SECTION("Conversion to and from json") {
         json json_boundary_condition = boundary_condition;
         std::cout << json_boundary_condition << std::endl;
         Boundary_Condition boundary_condition_from_json = json_boundary_condition;
         CHECK(boundary_condition_from_json == boundary_condition);
       }
+
       SECTION("Conversion to and from text") {
         std::stringstream ss{};
         ss << boundary_condition;
@@ -52,6 +54,7 @@ namespace lbm::core {
         ss >> boundary_condition_from_text;
         CHECK(boundary_condition_from_text == boundary_condition);
       }
+
       SECTION("Boundary ID access") { CHECK(boundary_condition.boundary() == north); }
     }
 
@@ -60,6 +63,10 @@ namespace lbm::core {
       constexpr double density = 1.0;
       constexpr double speed = 3.0;
       Boundary_Condition boundary_condition{Inlet{south, density, speed}};
+      std::cout << "************************************************************************\n";
+      std::cout << boundary_condition << std::endl;
+      std::cout << "************************************************************************\n";
+
       SECTION("Conversion to and from json") {
         json json_boundary_condition = boundary_condition;
         std::cout << json_boundary_condition << std::endl;
@@ -89,6 +96,7 @@ namespace lbm::core {
         Boundary_Condition boundary_condition_from_json = json_boundary_condition;
         CHECK(boundary_condition_from_json == boundary_condition);
       }
+
       SECTION("Conversion to and from text") {
         std::stringstream ss{};
         ss << boundary_condition;
@@ -96,21 +104,26 @@ namespace lbm::core {
         ss >> boundary_condition_from_text;
         CHECK(boundary_condition_from_text == boundary_condition);
       }
+
       SECTION("Boundary ID access") { CHECK(boundary_condition.boundary() == south); }
+
       SECTION("Density access") {
         CHECK(std::get<Outlet>(boundary_condition).density() == density);
       }
+
       SECTION("Speed access") { CHECK(std::get<Outlet>(boundary_condition).speed() == speed); }
     }
 
     SECTION("Pressure Drop") {
       Boundary_ID east = Right;
       Boundary_Condition boundary_condition{Pressure_Drop{east, 3.0}};
+
       SECTION("Conversion to and from json") {
         json json_boundary_condition = boundary_condition;
         Boundary_Condition boundary_condition_from_json = json_boundary_condition;
         CHECK(boundary_condition_from_json == boundary_condition);
       }
+
       SECTION("Conversion to and from text") {
         std::stringstream ss{};
         ss << boundary_condition;

--- a/test/cxx/fixed_array_index_test.cpp
+++ b/test/cxx/fixed_array_index_test.cpp
@@ -21,11 +21,11 @@
 namespace lbm::core::testing {
   using namespace std::literals;
 
-  TEST_CASE("Fixed Array Index") {
+  TEST_CASE("Fixed Multidimensional Array Index") {
 
     constexpr size_type a{3};
     constexpr size_type b{4};
-    constexpr Fixed_Array_Index idx{a, b};
+    constexpr Fixed_MD_Array_Index idx{a, b};
 
     SECTION("array access") {
 
@@ -42,14 +42,14 @@ namespace lbm::core::testing {
     SECTION("conversion to and from JSON") {
       nlohmann::json expected{{"FixedArrayIndex", {a, b}}};
       nlohmann::json json_idx = idx;
-      Fixed_Array_Index<2> idx_from_json(expected);
+      Fixed_MD_Array_Index<2> idx_from_json(expected);
 
       CHECK(json_idx == expected);
       CHECK(idx_from_json == idx);
     }
 
     SECTION("conversion to and from strings") {
-      Fixed_Array_Index<2> idx_from_string{};
+      Fixed_MD_Array_Index<2> idx_from_string{};
       std::stringstream ss;
       ss << idx;
       ss >> idx_from_string;

--- a/test/cxx/fixed_array_order_test.cpp
+++ b/test/cxx/fixed_array_order_test.cpp
@@ -21,21 +21,21 @@ namespace lbm::core::testing {
       using Order = Fixed_Lexical<2, 3>;
 
       SECTION("storage index") {
-        CHECK(Order::storage_index(Fixed_Array_Index(0, 0)) == 0);
-        CHECK(Order::storage_index(Fixed_Array_Index(0, 1)) == 1);
-        CHECK(Order::storage_index(Fixed_Array_Index(0, 2)) == 2);
-        CHECK(Order::storage_index(Fixed_Array_Index(1, 0)) == 3);
-        CHECK(Order::storage_index(Fixed_Array_Index(1, 1)) == 4);
-        CHECK(Order::storage_index(Fixed_Array_Index(1, 2)) == 5);
+        CHECK(Order::storage_index(Fixed_MD_Array_Index(0, 0)) == 0);
+        CHECK(Order::storage_index(Fixed_MD_Array_Index(0, 1)) == 1);
+        CHECK(Order::storage_index(Fixed_MD_Array_Index(0, 2)) == 2);
+        CHECK(Order::storage_index(Fixed_MD_Array_Index(1, 0)) == 3);
+        CHECK(Order::storage_index(Fixed_MD_Array_Index(1, 1)) == 4);
+        CHECK(Order::storage_index(Fixed_MD_Array_Index(1, 2)) == 5);
       }
 
       SECTION("array index") {
-        CHECK(Order::array_index(0) == Fixed_Array_Index(0, 0));
-        CHECK(Order::array_index(1) == Fixed_Array_Index(0, 1));
-        CHECK(Order::array_index(2) == Fixed_Array_Index(0, 2));
-        CHECK(Order::array_index(3) == Fixed_Array_Index(1, 0));
-        CHECK(Order::array_index(4) == Fixed_Array_Index(1, 1));
-        CHECK(Order::array_index(5) == Fixed_Array_Index(1, 2));
+        CHECK(Order::array_index(0) == Fixed_MD_Array_Index(0, 0));
+        CHECK(Order::array_index(1) == Fixed_MD_Array_Index(0, 1));
+        CHECK(Order::array_index(2) == Fixed_MD_Array_Index(0, 2));
+        CHECK(Order::array_index(3) == Fixed_MD_Array_Index(1, 0));
+        CHECK(Order::array_index(4) == Fixed_MD_Array_Index(1, 1));
+        CHECK(Order::array_index(5) == Fixed_MD_Array_Index(1, 2));
       }
 
       SECTION("conversion to and from JSON") {
@@ -58,25 +58,25 @@ namespace lbm::core::testing {
     SECTION("Degree 3") {
       using Order = Fixed_Lexical<2, 3, 4>;
       SECTION("storage index") {
-        CHECK(Order::storage_index(Fixed_Array_Index(0, 0, 0)) == 0);
-        CHECK(Order::storage_index(Fixed_Array_Index(0, 0, 1)) == 1);
-        CHECK(Order::storage_index(Fixed_Array_Index(0, 0, 2)) == 2);
-        CHECK(Order::storage_index(Fixed_Array_Index(0, 0, 3)) == 3);
-        CHECK(Order::storage_index(Fixed_Array_Index(0, 0, 1)) == 1);
-        CHECK(Order::storage_index(Fixed_Array_Index(0, 1, 0)) == 4);
-        CHECK(Order::storage_index(Fixed_Array_Index(1, 0, 0)) == 12);
-        CHECK(Order::storage_index(Fixed_Array_Index(1, 2, 3)) == 23);
+        CHECK(Order::storage_index(Fixed_MD_Array_Index(0, 0, 0)) == 0);
+        CHECK(Order::storage_index(Fixed_MD_Array_Index(0, 0, 1)) == 1);
+        CHECK(Order::storage_index(Fixed_MD_Array_Index(0, 0, 2)) == 2);
+        CHECK(Order::storage_index(Fixed_MD_Array_Index(0, 0, 3)) == 3);
+        CHECK(Order::storage_index(Fixed_MD_Array_Index(0, 0, 1)) == 1);
+        CHECK(Order::storage_index(Fixed_MD_Array_Index(0, 1, 0)) == 4);
+        CHECK(Order::storage_index(Fixed_MD_Array_Index(1, 0, 0)) == 12);
+        CHECK(Order::storage_index(Fixed_MD_Array_Index(1, 2, 3)) == 23);
       }
 
       SECTION("array index") {
-        CHECK(Order::array_index(0) == Fixed_Array_Index(0, 0, 0));
-        CHECK(Order::array_index(1) == Fixed_Array_Index(0, 0, 1));
-        CHECK(Order::array_index(2) == Fixed_Array_Index(0, 0, 2));
-        CHECK(Order::array_index(3) == Fixed_Array_Index(0, 0, 3));
-        CHECK(Order::array_index(1) == Fixed_Array_Index(0, 0, 1));
-        CHECK(Order::array_index(4) == Fixed_Array_Index(0, 1, 0));
-        CHECK(Order::array_index(12) == Fixed_Array_Index(1, 0, 0));
-        CHECK(Order::array_index(23) == Fixed_Array_Index(1, 2, 3));
+        CHECK(Order::array_index(0) == Fixed_MD_Array_Index(0, 0, 0));
+        CHECK(Order::array_index(1) == Fixed_MD_Array_Index(0, 0, 1));
+        CHECK(Order::array_index(2) == Fixed_MD_Array_Index(0, 0, 2));
+        CHECK(Order::array_index(3) == Fixed_MD_Array_Index(0, 0, 3));
+        CHECK(Order::array_index(1) == Fixed_MD_Array_Index(0, 0, 1));
+        CHECK(Order::array_index(4) == Fixed_MD_Array_Index(0, 1, 0));
+        CHECK(Order::array_index(12) == Fixed_MD_Array_Index(1, 0, 0));
+        CHECK(Order::array_index(23) == Fixed_MD_Array_Index(1, 2, 3));
       }
     }
   }

--- a/test/cxx/fixed_array_test.cpp
+++ b/test/cxx/fixed_array_test.cpp
@@ -17,12 +17,12 @@ namespace lbm::core::testing {
 
   TEST_CASE("Fixed Array") {
     SECTION("default initialization") {
-      Fixed_Array<double, Fixed_Lexical<2, 3, 4>> array{};
+      Fixed_MD_Array<double, Fixed_Lexical<2, 3, 4>> array{};
       CHECK(std::all_of(std::cbegin(array), std::cend(array), [](double x) { return x == 0.0; }));
     }
 
     SECTION("array access") {
-      Fixed_Array<double, Fixed_Lexical<3, 3>> array{};
+      Fixed_MD_Array<double, Fixed_Lexical<3, 3>> array{};
       CHECK(array.size() == 9);
       for (size_type i = 0; i < 3; ++i) {
         for (size_type j = 0; j < 3; ++j) {
@@ -36,7 +36,7 @@ namespace lbm::core::testing {
           });
     }
     SECTION("fill") {
-      Fixed_Array<double, Fixed_Lexical<3, 3>> array{};
+      Fixed_MD_Array<double, Fixed_Lexical<3, 3>> array{};
       array.fill(4.0);
       std::for_each(std::begin(array), std::end(array), [](const auto x) { CHECK(x == 4.0); });
     }

--- a/test/cxx/input_test.cpp
+++ b/test/cxx/input_test.cpp
@@ -91,7 +91,7 @@ namespace lbm::core::testing {
     }
 
     SECTION("Conversion to and from JSON") {
-
+      std::cout << json(input).dump(4) << std::endl;
       json json_input = input;
       Input input_from_json = json_input;
       CHECK(input == input_from_json);

--- a/test/cxx/input_test.cpp
+++ b/test/cxx/input_test.cpp
@@ -35,7 +35,9 @@ namespace lbm::core::testing {
     constexpr double width{200.0};
     constexpr double height{100.0};
     constexpr double lattice_spacing{0.5};
+    constexpr double inlet_density{1.0};
     constexpr double inlet_speed{4.0};
+    constexpr double outlet_density{1.0};
     constexpr double outlet_speed{4.0};
     constexpr double radius{5.0};
     const Euclidean velocity{u0, v0};
@@ -50,8 +52,8 @@ namespace lbm::core::testing {
         num_steps,
         Lattice{Bounding_Box{width, height}, lattice_spacing},
         Initial_Conditions{Initial_Density{density}, Initial_Velocity{constant(u0), constant(v0)}},
-        Boundary_Conditions{Inlet{Boundary_ID::Left, inlet_speed},
-                            Outlet{Boundary_ID::Right, outlet_speed},
+        Boundary_Conditions{Inlet{Boundary_ID::Left, inlet_density, inlet_speed},
+                            Outlet{Boundary_ID::Right, outlet_density, outlet_speed},
                             Wall{Boundary_ID::Bottom},
                             Wall{Boundary_ID::Top}},
         Obstacles{square(radius) - (square(x - center0[0]) + square(y - center0[1])),

--- a/test/data/valid-input.json
+++ b/test/data/valid-input.json
@@ -4,10 +4,10 @@
     "timeScale" : 1.0,
     "numSteps" : 100,
     "boundaryConditions": [
-        {"inlet": {"boundary": [-1, 0], "inletSpeed": 4.0}},
-        {"outlet": {"boundary": [1, 0], "outletSpeed": 4.0}},
-        {"wall": {"boundary": [0, -1]}},
-        {"wall": {"boundary": [0, 1]}}
+        {"inlet": {"boundary": "left", "dpeed": 4.0, "density": 1.0}},
+        {"outlet": {"boundary": "right", "speed": 4.0, "densitey": 1.0}},
+        {"wall": {"boundary": "bottom"}},
+        {"wall": {"boundary": "top"}}
     ],
     "initialConditions": {
         "density": 1.0,


### PR DESCRIPTION
Problem:
- The `CMakeUserPresets.json` generated by `make_user_presets.py`
doesn't set the `configuration` property for build presets or  test
presets.

Solution:
- Modify `make_user_presets.py` to generate presets with the
`configuration` property set.