### PR TITLE
:bug: [Input] Boundary Conditions are Optional

### DIFF
--- a/cxx/lbm/core/Input.cpp
+++ b/cxx/lbm/core/Input.cpp
@@ -76,9 +76,9 @@ namespace lbm::core {
     return lattice_.lattice_spacing();
   }
 
-  Boundary_Condition
+  optional<Boundary_Condition>
   Input::boundary(Boundary_ID id) const {
-    Boundary_Condition bc = Wall{id};
+    optional<Boundary_Condition> bc{};
     for (auto input_bc : boundary_conditions_) {
       if (input_bc.boundary() == id) {
         bc = input_bc;

--- a/cxx/lbm/core/Input.hpp
+++ b/cxx/lbm/core/Input.hpp
@@ -59,7 +59,7 @@ namespace lbm::core {
     double
     lattice_spacing() const;
 
-    Boundary_Condition
+    optional<Boundary_Condition>
     boundary(Boundary_ID id) const;
 
     friend bool

--- a/cxx/lbm/core/import.hpp
+++ b/cxx/lbm/core/import.hpp
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <iterator>
 #include <numeric>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -76,6 +77,9 @@ namespace lbm::core {
   // from iostream
   using std::istream;
   using std::ostream;
+
+  // from optional
+  using std::optional;
 
   // from sstream
   using std::ostringstream;


### PR DESCRIPTION
Problem:
- The `boundary_condition` member function for the `Input` class always returns a boundary condition, where the default is a wall if no boundary condition was specified.  This is not compatible with periodic boundaries or pressure drop boundaries where there are two boundaries linked by the condition

Solution:
- Return an optional value from `boundary_condition` and let the receiver decide whether it is a wall by default for linked to another boundary.